### PR TITLE
add total count to show()

### DIFF
--- a/src/hist1d.jl
+++ b/src/hist1d.jl
@@ -181,9 +181,10 @@ function Base.show(io::IO, h::Hist1D)
     _e = h.hist.edges[1]
     if _e isa AbstractRange && length(_e) < 50
         _h = Histogram(float(_e), h.hist.weights)
-        show(io, UnicodePlots.histogram(_h; width=30))
+        show(io, UnicodePlots.histogram(_h; width=35, margin=1, xlabel=""))
     end
     println()
     println(io, "edges: ", h.hist.edges[1])
-    print(io, "bin counts: ", h.hist.weights)
+    println(io, "bin counts: ", h.hist.weights)
+    print(io, "total count: ", sum(h.hist.weights))
 end

--- a/src/hist1d.jl
+++ b/src/hist1d.jl
@@ -181,7 +181,7 @@ function Base.show(io::IO, h::Hist1D)
     _e = h.hist.edges[1]
     if _e isa AbstractRange && length(_e) < 50
         _h = Histogram(float(_e), h.hist.weights)
-        show(io, UnicodePlots.histogram(_h; width=35, margin=1, xlabel=""))
+        show(io, UnicodePlots.histogram(_h; width=30, xlabel=""))
     end
     println()
     println(io, "edges: ", h.hist.edges[1])


### PR DESCRIPTION
Remove the useless "frequency" label and add the total count--very useful to verify at a glance that you filled it with the right number of events.

Before
```julia
julia> Hist1D(randn(100), -3:3)
                ┌                              ┐
   [-3.0, -2.0) ┤▇ 1
   [-2.0, -1.0) ┤▇▇▇▇▇▇▇▇▇▇ 14
   [-1.0,  0.0) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 35
   [ 0.0,  1.0) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 37
   [ 1.0,  2.0) ┤▇▇▇▇▇▇▇ 10
   [ 2.0,  3.0) ┤▇ 1
                └                              ┘
                           Frequency
edges: -3:3
bin counts: [1, 14, 35, 37, 10, 1]
```
After
```julia
julia> Hist1D(randn(100), -3:3) 
                ┌                              ┐
   [-3.0, -2.0) ┤▇▇▇ 4
   [-2.0, -1.0) ┤▇▇▇▇▇▇▇▇ 13
   [-1.0,  0.0) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 41
   [ 0.0,  1.0) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 22
   [ 1.0,  2.0) ┤▇▇▇▇▇▇▇▇▇▇ 16
   [ 2.0,  3.0) ┤▇▇▇ 4
                └                              ┘
edges: -3:3
bin counts: [4, 13, 41, 22, 16, 4]
total count: 100
```