### PR TITLE
Always compute/store sumw2

### DIFF
--- a/src/arithmatics.jl
+++ b/src/arithmatics.jl
@@ -36,8 +36,8 @@ for T in (:Hist1D,)
         _f(counts) = any(x -> x<0, counts)
         (_f(h1.hist.weights) || _f(h2.hist.weights)) && error("Can't do / when bin count is negative")
         _hist = /(h1.hist, h2.hist)
-        _sumw2 =  h1.sumw2 / (h2.hist.weights .^ 2) +
-                (sqrt.(h2.sumw2) * h1.hist.weights / (h2.hist.weights .^ 2)) .^ 2
+        _sumw2 =  @. h1.sumw2 / (h2.hist.weights ^ 2) +
+                (sqrt(h2.sumw2) * h1.hist.weights / (h2.hist.weights ^ 2)) ^ 2
                        
         ($T)(_hist, _sumw2)
     end

--- a/src/hist1d.jl
+++ b/src/hist1d.jl
@@ -35,12 +35,10 @@ function bincenters(h::Hist1D)
 end
 
 """
-    push!(h::Hist1D, val::Real)
     push!(h::Hist1D, val::Real, wgt::Real=one{T})
 
-Adding one value at a time into histogram. If `wgt` is supplied
-, this operation will accumulate `sumw2`
-(sum of weights^2) in the Hist automatically.
+Adding one value at a time into histogram. 
+`sumw2` (sum of weights^2) accumulates `wgt^2` with a default weight of 1.
 """
 function Base.push!(h::Hist1D{T,E}, val::Real, wgt::Real=one(T)) where {T,E}
     @inbounds binidx = searchsortedlast(h.hist.edges[1], val)

--- a/src/hist1d.jl
+++ b/src/hist1d.jl
@@ -40,7 +40,7 @@ end
 Adding one value at a time into histogram. 
 `sumw2` (sum of weights^2) accumulates `wgt^2` with a default weight of 1.
 """
-function Base.push!(h::Hist1D{T,E}, val::Real, wgt::Real=one(T)) where {T,E}
+function Base.push!(h::Hist1D{T,E}, val::Real, wgt::Real=1.0) where {T,E}
     @inbounds binidx = searchsortedlast(h.hist.edges[1], val)
     lock(h)
     @inbounds h.hist.weights[binidx] += wgt

--- a/src/hist1d.jl
+++ b/src/hist1d.jl
@@ -3,7 +3,7 @@ struct Hist1D{T<:Real,E} <: AbstractHistogram{T,1,E}
     sumw2::Vector{Float64}
     hlock::SpinLock
     # most concrete inner constructor
-    function Hist1D(h::Histogram{T,1,E}, sw2 = h.weights.^2) where {T,E}
+    function Hist1D(h::Histogram{T,1,E}, sw2 = h.weights) where {T,E}
         return new{T,E}(h, sw2, SpinLock())
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -66,7 +66,6 @@ end
 
 @testset "Arithmetic" begin
     @testset "Unweighted regular binning" begin
-        # Unweighted
         h1 = Hist1D([0.5,1.5,1.5,2.5], 0:3)
         h2 = Hist1D([0.5,1.5,2.5,2.5], 0:3)
 
@@ -92,7 +91,6 @@ end
     end
 
     @testset "Weighted regular binning" begin
-        # Weighted
         h1 = Hist1D([0.5,1.5,1.5,2.5], weights([3,3,2,1]), 0:3)
         h2 = Hist1D([0.5,1.5,2.5,2.5], weights([3,3,2,1]), 0:3)
 
@@ -102,7 +100,6 @@ end
     end
 
     @testset "Weighted irregular binning" begin
-        # Weighted nonuniform binning
         h1 = Hist1D([0.5,1.5,1.5,2.5], weights([3,3,2,1]), [0,1,2,4])
         h2 = Hist1D([0.5,1.5,2.5,2.5], weights([3,3,2,1]), [0,1,2,4])
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -63,3 +63,52 @@ end
         @test all(h1.hist.weights .≈ sth1.weights)
     end
 end
+
+@testset "Arithmetic" begin
+    @testset "Unweighted regular binning" begin
+        # Unweighted
+        h1 = Hist1D([0.5,1.5,1.5,2.5], 0:3)
+        h2 = Hist1D([0.5,1.5,2.5,2.5], 0:3)
+
+        h = h1 + h2
+        @test h.hist.weights == [2.0, 3.0, 3.0]
+        @test h.sumw2 == [2.0, 3.0, 3.0]
+
+        h = h1 - h2
+        @test h.hist.weights == [0.0, 1.0, -1.0]
+        @test h.sumw2 == [2.0, 3.0, 3.0]
+
+        h = h1 / h2
+        @test h.hist.weights == [1.0, 2.0, 0.5]
+        @test h.sumw2 == [2.0, 6.0, 0.375]
+
+        h = h1 * 2
+        @test h.hist.weights == [2.0, 4.0, 2.0]
+        @test h.sumw2 == [4.0, 8.0, 4.0]
+
+        h = h1/(h1+h2*2)
+        @test h.hist.weights ≈ [0.333333, 0.5, 0.2] atol=1e-6
+        @test h.sumw2 ≈ [0.17284, 0.21875, 0.0544] atol=1e-6
+    end
+
+    @testset "Weighted regular binning" begin
+        # Weighted
+        h1 = Hist1D([0.5,1.5,1.5,2.5], weights([3,3,2,1]), 0:3)
+        h2 = Hist1D([0.5,1.5,2.5,2.5], weights([3,3,2,1]), 0:3)
+
+        h = h1/(h1+h2*2)
+        @test h.hist.weights ≈ [0.333333, 0.454545, 0.142857] atol=1e-6
+        @test h.sumw2 ≈ [0.17284, 0.191107, 0.029155] atol=1e-6
+    end
+
+    @testset "Weighted irregular binning" begin
+        # Weighted nonuniform binning
+        h1 = Hist1D([0.5,1.5,1.5,2.5], weights([3,3,2,1]), [0,1,2,4])
+        h2 = Hist1D([0.5,1.5,2.5,2.5], weights([3,3,2,1]), [0,1,2,4])
+
+        h = h1/(h1+h2*2)
+        @test h.hist.weights ≈ [0.333333, 0.454545, 0.142857] atol=1e-6
+        @test h.sumw2 ≈ [0.17284, 0.191107, 0.029155] atol=1e-6
+    end
+
+end


### PR DESCRIPTION
Closes https://github.com/Moelf/FHist.jl/issues/8 and https://github.com/Moelf/FHist.jl/issues/7

Changes
* `Hist1D` default constructor set sumw2 equal to the counts (weight=1)
* single `push!()` with optional weight=1
* `Hist1D(A::AbstractVector, r::AbstractRange{T})` (regular binning) also computes sumw2 in the loop
* `Hist1D(A, wgts::AbstractWeights, edges::AbstractVector)` (irregular binning) runs `fit(Histogram, ...)` twice: once with regular counts and again with `weights^2`. The latter is fed into the default `Hist1D` constructor as sumw2.

Now histogram arithmetic test cases from ROOT work for regular and irregular binning with and without specified weights.