### PR TITLE
factor out bin calculation and optimize push!()

### DIFF
--- a/src/FHist.jl
+++ b/src/FHist.jl
@@ -1,6 +1,7 @@
 module FHist
 
 export Hist1D, sample
+export unsafe_push!
 
 using StatsBase, RecipesBase, UnicodePlots
 import LinearAlgebra: normalize, normalize!

--- a/src/hist1d.jl
+++ b/src/hist1d.jl
@@ -69,6 +69,9 @@ end
 Adding one value at a time into histogram. 
 `sumw2` (sum of weights^2) accumulates `wgt^2` with a default weight of 1.
 `unsafe_push!` is a faster version of `push!` that is not thread-safe.
+
+N.B. To append multiple values at once, use broadcasting via
+`push!.(h, [-3.0, -2.9, -2.8])` or `push!.(h, [-3.0, -2.9, -2.8], 2.0)`
 """
 @inline function Base.push!(h::Hist1D{T,E}, val::Real, wgt::Real=1.0) where {T,E}
     r = h.hist.edges[1]
@@ -99,6 +102,8 @@ end
     @inbounds h.sumw2[binidx] += c*wgt^2
     return nothing
 end
+
+Base.broadcastable(h::Hist1D) = Ref(h)
 
 """
     Hist1D(elT::Type{T}=Float64; binedges) where {T}

--- a/src/hist1d.jl
+++ b/src/hist1d.jl
@@ -24,6 +24,23 @@ function sample(h::Hist1D, n::Int)
     @inbounds sample(@view(only(h.hist.edges)[1:end-1]), Weights(h.hist.weights), n)
 end
 
+
+@inline function _edge_binindex(r::AbstractRange{T}, x::Real) where T <:  AbstractFloat
+    s = step(r)
+    start = first(r) + 0.5s
+    return round(Int, (x - start) / s) + 1
+end
+
+@inline function _edge_binindex(r::AbstractRange{T}, x::Real) where T <:  Integer
+    s = step(r)
+    start = first(r)
+    return Int(fld(x-start, s)) + 1
+end
+
+@inline function _edge_binindex(v::AbstractVector, x::Real)
+    return searchsortedlast(v, x)
+end
+
 """
     bincenters(h::Hist1D)
 
@@ -35,18 +52,36 @@ function bincenters(h::Hist1D)
 end
 
 """
-    push!(h::Hist1D, val::Real, wgt::Real=one{T})
+    empty!(h::Hist1D)
+
+Resets a histogram's bin counts and `sumw2`.
+"""
+function Base.empty!(h::Hist1D{T,E}) where {T,E}
+    h.hist.weights .= zero(T)
+    h.sumw2 .= zero(T)
+    return h
+end
+
+"""
+    push!(h::Hist1D, val::Real, wgt::Real=1.0)
+    unsafe_push!(h::Hist1D, val::Real, wgt::Real=1.0)
 
 Adding one value at a time into histogram. 
 `sumw2` (sum of weights^2) accumulates `wgt^2` with a default weight of 1.
+`unsafe_push!` is a faster version of `push!` that is not thread-safe.
 """
 function Base.push!(h::Hist1D{T,E}, val::Real, wgt::Real=1.0) where {T,E}
-    @inbounds binidx = searchsortedlast(h.hist.edges[1], val)
+    @inbounds binidx = _edge_binindex(h.hist.edges[1], val)
     lock(h)
     @inbounds h.hist.weights[binidx] += wgt
     @inbounds h.sumw2[binidx] += wgt^2
     unlock(h)
-    return h
+end
+
+function unsafe_push!(h::Hist1D{T,E}, val::Real, wgt::Real=1.0) where {T,E}
+    @inbounds binidx = _edge_binindex(h.hist.edges[1], val)
+    @inbounds h.hist.weights[binidx] += wgt
+    @inbounds h.sumw2[binidx] += wgt^2
 end
 
 """
@@ -67,24 +102,7 @@ end
 Create a `Hist1D` with given bin `edges` and vlaues from
 array. Weight for each value is assumed to be 1.
 """
-function Hist1D(A::AbstractVector, r::AbstractRange{T}) where T <: AbstractFloat
-    s = step(r)
-    start = first(r)
-    start2 = start + 0.5s
-    stop = last(r)
-    L = length(r) - 1
-    counts = zeros(Int, L)
-    @inbounds for idx in eachindex(A)
-        # skip overflow
-        i = A[idx]
-        c = ifelse(i > stop, 0, 1)
-        c = ifelse(i < start, 0, c)
-        id = round(Int, (i - start2) / s) + 1
-        counts[clamp(id, 1, L)] += c
-    end
-    return Hist1D(Histogram(r, counts))
-end
-function Hist1D(A::AbstractVector, r::AbstractRange{T}) where T <: Integer
+function Hist1D(A::AbstractVector, r::AbstractRange{T}) where T <: Union{AbstractFloat,Integer}
     s = step(r)
     start = first(r)
     stop = last(r)
@@ -95,7 +113,7 @@ function Hist1D(A::AbstractVector, r::AbstractRange{T}) where T <: Integer
         i = A[idx]
         c = ifelse(i > stop, 0, 1)
         c = ifelse(i < start, 0, c)
-        id = Int(fld(i-start, s)) + 1
+        id = _edge_binindex(r, i)
         counts[clamp(id, 1, L)] += c
     end
     return Hist1D(Histogram(r, counts))

--- a/src/hist1d.jl
+++ b/src/hist1d.jl
@@ -63,8 +63,8 @@ function Base.empty!(h::Hist1D{T,E}) where {T,E}
 end
 
 """
-    unsafe_push!(h::Hist1D, val::Real, wgt::Real=1.0)
-    push!(h::Hist1D, val::Real, wgt::Real=1.0)
+    unsafe_push!(h::Hist1D, val::Real, wgt::Real=1)
+    push!(h::Hist1D, val::Real, wgt::Real=1)
 
 Adding one value at a time into histogram. 
 `sumw2` (sum of weights^2) accumulates `wgt^2` with a default weight of 1.
@@ -73,7 +73,7 @@ Adding one value at a time into histogram.
 N.B. To append multiple values at once, use broadcasting via
 `push!.(h, [-3.0, -2.9, -2.8])` or `push!.(h, [-3.0, -2.9, -2.8], 2.0)`
 """
-@inline function Base.push!(h::Hist1D{T,E}, val::Real, wgt::Real=1.0) where {T,E}
+@inline function Base.push!(h::Hist1D{T,E}, val::Real, wgt::Real=1) where {T,E}
     r = h.hist.edges[1]
     L = length(r) - 1
     start = first(r)
@@ -88,7 +88,7 @@ N.B. To append multiple values at once, use broadcasting via
     return nothing
 end
 
-@inline function unsafe_push!(h::Hist1D{T,E}, val::Real, wgt::Real=1.0) where {T,E}
+@inline function unsafe_push!(h::Hist1D{T,E}, val::Real, wgt::Real=1) where {T,E}
     r = h.hist.edges[1]
     L = length(r) - 1
     start = first(r)

--- a/src/hist1d.jl
+++ b/src/hist1d.jl
@@ -71,17 +71,23 @@ Adding one value at a time into histogram.
 `unsafe_push!` is a faster version of `push!` that is not thread-safe.
 """
 function Base.push!(h::Hist1D{T,E}, val::Real, wgt::Real=1.0) where {T,E}
-    @inbounds binidx = _edge_binindex(h.hist.edges[1], val)
+    r = h.hist.edges[1]
+    !(first(r) <= val <= last(r)) && return nothing
+    @inbounds binidx = _edge_binindex(r, val)
     lock(h)
     @inbounds h.hist.weights[binidx] += wgt
     @inbounds h.sumw2[binidx] += wgt^2
     unlock(h)
+    return nothing
 end
 
 function unsafe_push!(h::Hist1D{T,E}, val::Real, wgt::Real=1.0) where {T,E}
-    @inbounds binidx = _edge_binindex(h.hist.edges[1], val)
+    r = h.hist.edges[1]
+    !(first(r) <= val <= last(r)) && return nothing
+    @inbounds binidx = _edge_binindex(r, val)
     @inbounds h.hist.weights[binidx] += wgt
     @inbounds h.sumw2[binidx] += wgt^2
+    return nothing
 end
 
 """

--- a/src/hist1d.jl
+++ b/src/hist1d.jl
@@ -58,7 +58,7 @@ Resets a histogram's bin counts and `sumw2`.
 """
 function Base.empty!(h::Hist1D{T,E}) where {T,E}
     h.hist.weights .= zero(T)
-    h.sumw2 .= zero(T)
+    h.sumw2 .= 0.0
     return h
 end
 

--- a/src/hist1d.jl
+++ b/src/hist1d.jl
@@ -74,16 +74,8 @@ N.B. To append multiple values at once, use broadcasting via
 `push!.(h, [-3.0, -2.9, -2.8])` or `push!.(h, [-3.0, -2.9, -2.8], 2.0)`
 """
 @inline function Base.push!(h::Hist1D{T,E}, val::Real, wgt::Real=1) where {T,E}
-    r = h.hist.edges[1]
-    L = length(r) - 1
-    start = first(r)
-    stop = last(r)
-    c = ifelse(val > stop, 0, 1)
-    c = ifelse(val < start, 0, c)
-    binidx = clamp(_edge_binindex(r, val), 1, L)
     lock(h)
-    @inbounds h.hist.weights[binidx] += c*wgt
-    @inbounds h.sumw2[binidx] += c*wgt^2
+    unsafe_push!(h, val, wgt)
     unlock(h)
     return nothing
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -87,6 +87,19 @@ end
     @test h1 == h3
 end
 
+@testset "Broadcasted push" begin
+    lookup(h::Hist1D, value) = h.hist.weights[FHist._edge_binindex(h.hist.edges[1], value)]
+
+    h1 = Hist1D(Int; bins=0:3)
+
+    push!.(h1, [0.5, 1.5])
+    @test lookup.(h1, [0.5,1.5,2.5]) == [1, 1, 0]
+
+    empty!(h1)
+    push!.(h1, [0.5, 1.5], 2)
+    @test lookup.(h1, [0.5,1.5,2.5]) == [2, 2, 0]
+end
+
 @testset "Arithmetic" begin
     @testset "Unweighted regular binning" begin
         h1 = Hist1D([0.5,1.5,1.5,2.5], 0:3)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -64,6 +64,29 @@ end
     end
 end
 
+@testset "Empty" begin
+    a = rand(10^5)
+    r = 0:0.1:1
+    h1 = Hist1D(a, r)
+    empty!(h1)
+    @test maximum(h1.hist.weights) == 0
+    @test maximum(h1.sumw2) == 0
+    @test h1.hist.edges[1] == r
+end
+
+@testset "Unsafe push" begin
+    a = randn(10^5)
+    h1 = Hist1D(a, -3:0.2:3)
+    h2 = Hist1D(Int; bins=-3:0.2:3)
+    h3 = Hist1D(Int; bins=-3:0.2:3)
+    for i in a
+        push!(h2, i)
+        FHist.unsafe_push!(h3, i)
+    end
+    @test h1 == h2
+    @test h1 == h3
+end
+
 @testset "Arithmetic" begin
     @testset "Unweighted regular binning" begin
         h1 = Hist1D([0.5,1.5,1.5,2.5], 0:3)


### PR DESCRIPTION
Closes https://github.com/Moelf/FHist.jl/issues/11

* Factored out bin calculation logic for float range, int range, irregular binning.
* Added `empty!()` to reset hists
* Added thread-UNsafe `unsafe_push!()`
* Defined `Base.broadcastable(h::Hist1D) = Ref(h)` so one can do `push!.(h, [-3.0, -2.9, -2.8])` or `push!.(h, [-3.0, -2.9, -2.8], 2.0)` as a "broadcasted push".

### Master
```julia
julia> using Revise, FHist, BenchmarkTools, StatsBase, StatProfilerHTML

julia> a = randn(10^6);

# one-shot construction
julia> @benchmark Hist1D(a, -3:0.1:3)
BechmarkTools.Trial: 1239 samples with 1 evaluations.
 Range (min … max):  3.577 ms …   5.555 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     3.957 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   4.024 ms ± 271.173 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%
 Memory estimate: 1.31 KiB, allocs estimate: 6.

julia> h = Hist1D(Int; bins=-3:0.1:3);

# thread-safe iterative construction
julia> @benchmark for i in $a push!($h, i) end
BechmarkTools.Trial: 70 samples with 1 evaluations.
 Range (min … max):  67.342 ms … 92.730 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     70.394 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   71.623 ms ±  4.372 ms  ┊ GC (mean ± σ):  0.00% ± 0.00%
 Memory estimate: 0 bytes, allocs estimate: 0.
```
### This PR

```julia
# one-shot construction
julia> @benchmark Hist1D(a, 3:0.1:3)
 Range (min … max):  3.271 ms …   5.076 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     3.472 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   3.511 ms ± 160.078 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

# thread-safe iterative construction
julia> @benchmark for i in $a push!($h, i) end
 Range (min … max):  27.190 ms …  33.794 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     28.067 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   28.241 ms ± 920.786 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%
 Memory estimate: 0 bytes, allocs estimate: 0.

# thread-unsafe iterative construction
julia> @benchmark for i in $a unsafe_push!($h, i) end
 Range (min … max):  4.251 ms …   6.034 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     4.563 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   4.601 ms ± 189.220 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%
```

So, a ~2.5x speedup wrt master for `push!()` and apparently `@inline` + removing locks gives another ~6x speedup! `unsafe_push!()` is roughly the same speed as the one-shot method.