### PR TITLE
optimize int binning

### DIFF
--- a/src/hist1d.jl
+++ b/src/hist1d.jl
@@ -20,17 +20,8 @@ function sample(h::Hist1D; n::Int=1)
     StatsBase.sample(binedges(h)[1:end-1], Weights(bincounts(h)), n)
 end
 
-
-@inline function _edge_binindex(r::AbstractRange{T}, x::Real) where T <:  AbstractFloat
-    s = step(r)
-    start = first(r) + 0.5s
-    return round(Int, (x - start) / s) + 1
-end
-
-@inline function _edge_binindex(r::AbstractRange{T}, x::Real) where T <:  Integer
-    s = step(r)
-    start = first(r)
-    return Int(fld(x-start, s)) + 1
+@inline function _edge_binindex(r::AbstractRange, x::Real)
+    return floor(Int, (x - first(r)) / step(r)) + 1
 end
 
 @inline function _edge_binindex(v::AbstractVector, x::Real)

--- a/src/hist1d.jl
+++ b/src/hist1d.jl
@@ -102,15 +102,11 @@ end
 @inline function unsafe_push!(h::Hist1D{T,E}, val::Real, wgt::Real=1) where {T,E}
     r = @inbounds h.hist.edges[1]
     L = length(r) - 1
-    start = first(r)
-    stop = last(r)
-    c = ifelse(val > stop, 0, 1)
-    c = ifelse(val < start, 0, c)
     binidx = _edge_binindex(r, val)
-    binidx = ifelse(binidx > L, L, binidx)
-    binidx = ifelse(binidx < 1, 1, binidx)
-    @inbounds h.hist.weights[binidx] += c*wgt
-    @inbounds h.sumw2[binidx] += c*wgt^2
+    if 1 <= binidx <= L
+        @inbounds h.hist.weights[binidx] += wgt
+        @inbounds h.sumw2[binidx] += wgt^2
+    end
     return nothing
 end
 

--- a/src/hist1d.jl
+++ b/src/hist1d.jl
@@ -254,7 +254,7 @@ function Base.show(io::IO, h::Hist1D)
         _h = Histogram(float(_e), bincounts(h))
         show(io, UnicodePlots.histogram(_h; width=30, xlabel=""))
     end
-    println()
+    println(io)
     println(io, "edges: ", binedges(h))
     println(io, "bin counts: ", bincounts(h))
     print(io, "total count: ", sum(bincounts(h)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -187,3 +187,15 @@ end
     end
 
 end
+
+@testset "Merging" begin
+    h1 = Hist1D(randn(100), -3:3)
+    h2 = Hist1D(randn(100), -3:3)
+    @test merge(h1,h2) == h1+h2
+end
+
+@testset "Repr" begin
+    h1 = Hist1D(randn(100), -3:3)
+    @test all(occursin(repr(h1)).(["edges:", "total count:", "bin counts:"]))
+end
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -196,6 +196,6 @@ end
 
 @testset "Repr" begin
     h1 = Hist1D(randn(100), -3:3)
-    @test all(occursin(repr(h1)).(["edges:", "total count:", "bin counts:"]))
+    @test all(occursin.(["edges:", "total count:", "bin counts:"], repr(h1)))
 end
 


### PR DESCRIPTION
* combined the AbstractFloat and Integer implementations. 
* swapped the `+0.5`/`round` for just `floor` based on what I saw in https://github.com/joshday/OnlineStats.jl/blob/master/src/stats/histograms.jl. Though if I benchmark their hist, it's ~3-4x slower than FHist, probably related to them not using `@inline`. 3-4x is the speedup I observed when adding `@inline` in front of `unsafe_push!()`
* the `ifelse` chain evidently wasn't even triggering simd, so the implementation is simpler now.


`-3:0.1:3` is slightly faster, and `-3:3` is even faster (and 8x faster than master).


Before (`master`):
```julia
julia> a = randn(10^6);

julia> @benchmark Hist1D(a, -3:0.1:3)
BechmarkTools.Trial: 1142 samples with 1 evaluations.
 Range (min … max):  3.839 ms …   6.746 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     4.313 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   4.372 ms ± 239.986 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%
 Memory estimate: 1.98 KiB, allocs estimate: 9.

julia> @benchmark Hist1D(a, -3:3)
BechmarkTools.Trial: 230 samples with 1 evaluations.
 Range (min … max):  20.159 ms …  25.909 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     21.708 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   21.794 ms ± 779.543 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%
 Memory estimate: 592 bytes, allocs estimate: 8.
```

After:
```julia
julia> a = randn(10^6);

julia> @benchmark Hist1D(a, -3:0.1:3)
BechmarkTools.Trial: 1244 samples with 1 evaluations.
 Range (min … max):  3.550 ms …   9.857 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     3.895 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   4.006 ms ± 412.422 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%
 Memory estimate: 1.98 KiB, allocs estimate: 9.

julia> @benchmark Hist1D(a, -3:3)
BechmarkTools.Trial: 1838 samples with 1 evaluations.
 Range (min … max):  2.465 ms …   4.494 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     2.633 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   2.711 ms ± 204.492 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%
 Memory estimate: 592 bytes, allocs estimate: 8.
```