### PR TITLE
[WIP] add threading

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,6 +8,7 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+ThreadsX = "ac1d9e8a-700a-412c-b207-f0111f4b6c0d"
 UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
 
 [compat]

--- a/src/FHist.jl
+++ b/src/FHist.jl
@@ -5,8 +5,9 @@ export sample, lookup, cumulative, normalize
 export unsafe_push!
 
 using StatsBase, RecipesBase, UnicodePlots, Statistics
+using ThreadsX
 import LinearAlgebra: normalize, normalize!
-using Base.Threads: SpinLock
+using Base.Threads: SpinLock, nthreads
 
 @inline function pearson_err(n::Real)
     s = sqrt(n+0.25)


### PR DESCRIPTION
Add threading for two of the one-shot `Hist1D` creation methods:
- `Hist1D(A::AbstractVector, r::AbstractRange)`
- `Hist1D(A, wgts::AbstractWeights, r::AbstractRange)`

With `julia`
```julia
julia> using FHist, BenchmarkTools

julia> a = randn(10^6);

julia> @benchmark Hist1D(a, -3:0.01:3)
BechmarkTools.Trial: 1331 samples with 1 evaluations.
 Range (min … max):  3.388 ms …   5.618 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     3.728 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   3.752 ms ± 192.946 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%
 Memory estimate: 14.83 KiB, allocs estimate: 11.
```

The time is identical to the previous implementation (without threading) since the overhead is only a few microseconds.

With `julia -t 4`
```julia
julia> using FHist, BenchmarkTools

julia> a = randn(10^6);

julia> @benchmark Hist1D(a, -3:0.01:3)
BechmarkTools.Trial: 4004 samples with 1 evaluations.
 Range (min … max):  1.034 ms …  36.823 ms  ┊ GC (min … max): 0.00% … 95.78%
 Time  (median):     1.158 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   1.237 ms ± 834.498 μs  ┊ GC (mean ± σ):  1.78% ±  2.62%
 Memory estimate: 90.08 KiB, allocs estimate: 78.
```

1ms for 1M entries -> 1GHz.