### PR TITLE
add rebinning method

### DIFF
--- a/src/FHist.jl
+++ b/src/FHist.jl
@@ -1,7 +1,7 @@
 module FHist
 
 export Hist1D, binedges, bincounts, bincenters, nbins, integral
-export sample, lookup, cumulative, normalize
+export sample, lookup, cumulative, normalize, rebin
 export unsafe_push!
 
 using StatsBase, RecipesBase, UnicodePlots, Statistics

--- a/src/hist1d.jl
+++ b/src/hist1d.jl
@@ -249,14 +249,15 @@ function cumulative(h::Hist1D; forward=true)
 end
 
 """
-    rebin(h::Hist1D, ngroup::Int=1)
-    rebin(ngroup::Int) = h::Hist1D -> rebin(h, ngroup)
+    rebin(h::Hist1D, n::Int=1)
+    rebin(n::Int) = h::Hist1D -> rebin(h, n)
 
-Merges `ngroup` consecutive bins into one.
+Merges `n` consecutive bins into one.
+The returned histogram will have `nbins(h)/n` bins.
 """
-function rebin(h::Hist1D, ngroup::Int=1)
-    @assert nbins(h) % ngroup == 0
-    p = x->Iterators.partition(x, ngroup)
+function rebin(h::Hist1D, n::Int=1)
+    @assert nbins(h) % n == 0
+    p = x->Iterators.partition(x, n)
     counts = sum.(p(bincounts(h)))
     sumw2 = sum.(p(h.sumw2))
     edges = first.(p(binedges(h)))
@@ -266,7 +267,7 @@ function rebin(h::Hist1D, ngroup::Int=1)
     end
     return Hist1D(Histogram(edges, counts), sumw2)
 end
-rebin(ngroup::Int) = Base.Fix2(rebin, ngroup)
+rebin(n::Int) = Base.Fix2(rebin, n)
 
 function Base.show(io::IO, h::Hist1D)
     _e = binedges(h)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -194,6 +194,20 @@ end
     @test merge(h1,h2) == h1+h2
 end
 
+@testset "Rebinning" begin
+    h1 = Hist1D(rand(10^2), 0:0.1:1)
+    @test h1 == rebin(h1, 1)
+    @test integral(h1) == integral(rebin(h1, 5))
+    @test sum(h1.sumw2) == sum(rebin(h1, 5).sumw2)
+
+    h2 = Hist1D(rand(10^2), [0.0, 0.1, 0.7, 0.9, 1.0])
+    @test h2 == rebin(h2, 1)
+    @test integral(h2) == integral(rebin(h2, 2))
+    @test sum(h2.sumw2) == sum(rebin(h2, 2).sumw2)
+
+    @test rebin(h1, 2) == (h1 |> rebin(2))
+end
+
 @testset "Repr" begin
     h1 = Hist1D(randn(100), -3:3)
     @test all(occursin.(["edges:", "total count:", "bin counts:"], repr(h1)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -199,11 +199,13 @@ end
     @test h1 == rebin(h1, 1)
     @test integral(h1) == integral(rebin(h1, 5))
     @test sum(h1.sumw2) == sum(rebin(h1, 5).sumw2)
+    @test binedges(rebin(h1, 5)) == [0, 0.5, 1.0]
 
     h2 = Hist1D(rand(10^2), [0.0, 0.1, 0.7, 0.9, 1.0])
     @test h2 == rebin(h2, 1)
     @test integral(h2) == integral(rebin(h2, 2))
     @test sum(h2.sumw2) == sum(rebin(h2, 2).sumw2)
+    @test binedges(rebin(h2, 2)) == [0, 0.7, 1.0]
 
     @test rebin(h1, 2) == (h1 |> rebin(2))
 end


### PR DESCRIPTION
Adding another feature from https://github.com/Moelf/FHist.jl/issues/13.

```julia
julia> using FHist

julia> h = Hist1D(randn(10^3))
                ┌                              ┐
   [-3.0, -2.5) ┤ 1
   [-2.5, -2.0) ┤▇ 11
   [-2.0, -1.5) ┤▇▇▇▇▇ 44
   [-1.5, -1.0) ┤▇▇▇▇▇▇▇▇▇▇▇▇ 101
   [-1.0, -0.5) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 160
   [-0.5,  0.0) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 203
   [ 0.0,  0.5) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 186
   [ 0.5,  1.0) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 147
   [ 1.0,  1.5) ┤▇▇▇▇▇▇▇▇▇▇▇ 91
   [ 1.5,  2.0) ┤▇▇▇▇ 32
   [ 2.0,  2.5) ┤▇▇ 20
   [ 2.5,  3.0) ┤ 4
                └                              ┘
edges: -3.0:0.5:3.0
bin counts: [1, 11, 44, 101, 160, 203, 186, 147, 91, 32, 20, 4]
total count: 1000
```
```julia
julia> rebin(h, 2)
                ┌                              ┐
   [-3.0, -2.0) ┤▇ 12
   [-2.0, -1.0) ┤▇▇▇▇▇▇▇▇▇▇ 145
   [-1.0,  0.0) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 363
   [ 0.0,  1.0) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 333
   [ 1.0,  2.0) ┤▇▇▇▇▇▇▇▇ 123
   [ 2.0,  3.0) ┤▇▇ 24
                └                              ┘
edges: -3.0:1.0:3.0
bin counts: [12, 145, 363, 333, 123, 24]
total count: 1000
```
```julia
julia> h |> rebin(2)
                ┌                              ┐
   [-3.0, -2.0) ┤▇ 12
   [-2.0, -1.0) ┤▇▇▇▇▇▇▇▇▇▇ 145
   [-1.0,  0.0) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 363
   [ 0.0,  1.0) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 333
   [ 1.0,  2.0) ┤▇▇▇▇▇▇▇▇ 123
   [ 2.0,  3.0) ┤▇▇ 24
                └                              ┘
edges: -3.0:1.0:3.0
bin counts: [12, 145, 363, 333, 123, 24]
total count: 1000
```

There's also a curried `rebin(ngroup::Int) = Base.Fix2(rebin, ngroup)` that could be convenient, but I don't have strong feelings either way and could take it out.