### PR TITLE
optimize integer binning

### DIFF
--- a/src/hist1d.jl
+++ b/src/hist1d.jl
@@ -24,6 +24,10 @@ end
     return floor(Int, (x - first(r)) / step(r)) + 1
 end
 
+@inline function _edge_binindex(r::AbstractRange{<:Integer}, x::Integer)
+    return x - first(r) + 1
+end
+
 @inline function _edge_binindex(v::AbstractVector, x::Real)
     return searchsortedlast(v, x)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -64,6 +64,14 @@ end
     end
 end
 
+@testset "Special binning cases" begin
+    # integer values and integer binning
+    a = floor.(Int,abs.(randn(10^6)))
+    h1 = Hist1D(a, 0:5)
+    h2 = Hist1D(fit(Histogram, a, 0:5))
+    @test h1 == h2
+end
+
 @testset "Normalize" begin
     a = rand(10^5)
     wgts1 = 2 .* ones(10^5) |> weights


### PR DESCRIPTION
Add a simple specialized `_edge_binindex(r::AbstractRange{<:Integer}, x::Integer) = return x - first(r) + 1`

```julia
julia> a = floor.(Int,abs.(randn(10^6).*2));

julia> Hist1D(a, 0:10)
                ┌                              ┐
   [ 0.0,  1.0) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 382988
   [ 1.0,  2.0) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 300585
   [ 2.0,  3.0) ┤▇▇▇▇▇▇▇▇▇▇▇ 183317
   [ 3.0,  4.0) ┤▇▇▇▇▇ 87695
   [ 4.0,  5.0) ┤▇▇ 33310
   [ 5.0,  6.0) ┤▇ 9477
   [ 6.0,  7.0) ┤ 2167
   [ 7.0,  8.0) ┤ 375
   [ 8.0,  9.0) ┤ 79
   [ 9.0, 10.0) ┤ 7
                └                              ┘
edges: 0:10
bin counts: [382988, 300585, 183317, 87695, 33310, 9477, 2167, 375, 79, 7]
total count: 1000000
```

### Before
```julia
julia> @benchmark Hist1D(a, 0:10)
BechmarkTools.Trial: 2060 samples with 1 evaluations.
 Range (min … max):  2.276 ms …   4.540 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     2.376 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   2.419 ms ± 166.406 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%
 Memory estimate: 688 bytes, allocs estimate: 8.
```

### After
```julia
julia> @benchmark Hist1D(a, 0:10)
BechmarkTools.Trial: 2842 samples with 1 evaluations.
 Range (min … max):  1.653 ms …   4.025 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     1.701 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   1.751 ms ± 180.736 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%
 Memory estimate: 688 bytes, allocs estimate: 8.
```
--> ~28% improvement