### PR TITLE
svg repr in notebooks

### DIFF
--- a/src/hist1d.jl
+++ b/src/hist1d.jl
@@ -252,6 +252,37 @@ function cumulative(h::Hist1D; forward=true)::Hist1D
     return h
 end
 
+function _svg(h::Hist1D)
+    paddingx, paddingy = 0.05, 0.10
+    framewidth, frameheight = 250, 200
+    fill = "#ffffff00" # 0 alpha
+    strokecolor, strokewidth = "black", 1
+    strokewidth = 1
+    _c, _e = bincounts(h), binedges(h)
+    ys = frameheight * ((2*paddingy-1)/maximum(_c) .* _c .+ (1-paddingy))
+    xs = framewidth * (
+        (1 - 2 * paddingx) / (maximum(_e) - minimum(_e))
+        .* (_e .- minimum(_e))
+        .+ paddingx
+    )
+    points = [(paddingx*framewidth, (1-paddingy)*frameheight)] # bottom left
+    for i in 1:(length(xs)-1)
+        push!(points, (xs[i],ys[i])) # left bin edge
+        push!(points, (xs[i+1],ys[i])) # right bin edge
+    end
+    push!(points, ((1-paddingx)*framewidth,(1-paddingy)*frameheight))
+    push!(points, points[1]) # close path
+    pathstr = join(["$(x),$(y)" for (x,y) in points],",")
+    return """
+    <svg width="$(framewidth)" height="$(frameheight)" version="1.1" xmlns="http://www.w3.org/2000/svg">
+        <polyline points="$(pathstr)" stroke="$(strokecolor)" fill="$(fill)" stroke-width="$(strokewidth)"/>
+        <polyline points="$(framewidth*paddingx),$(frameheight*(1-paddingy)),$(framewidth*(1-paddingx)),$(frameheight*(1-paddingy))" stroke="black" stroke-width="1"/>
+        <text x="$(framewidth*paddingx)" y="$(frameheight*(1-0.5*paddingy))" dominant-baseline="middle" text-anchor="start" fill="black">$(minimum(_e))</text>
+        <text x="$(framewidth*(1-paddingx))" y="$(frameheight*(1-0.5*paddingy))" dominant-baseline="middle" text-anchor="end" fill="black">$(maximum(_e))</text>
+    </svg>
+    """
+end
+
 function Base.show(io::IO, h::Hist1D)
     _e = binedges(h)
     if nbins(h) < 50
@@ -262,4 +293,18 @@ function Base.show(io::IO, h::Hist1D)
     println(io, "edges: ", binedges(h))
     println(io, "bin counts: ", bincounts(h))
     print(io, "total count: ", sum(bincounts(h)))
+end
+
+function Base.show(io::IO, m::MIME"text/html", h::Hist1D)
+    println(io, """
+    <div style="display: flex;">
+        <div style="float:left; margin:5px">$(_svg(h))</div>
+        <div style="float:left; margin:5px; display:flex; justify-content:center; align-items:center; text-overflow:ellipsis;">
+            edges: $(repr(binedges(h), context=:limit => true))<br>
+            bin counts: $(repr(bincounts(h), context=:limit => true))<br>
+            maximum count: $(maximum(bincounts(h)))<br>
+            total count: $(sum(bincounts(h)))
+        </div>
+    </div>
+    """)
 end

--- a/src/hist1d.jl
+++ b/src/hist1d.jl
@@ -299,11 +299,13 @@ function Base.show(io::IO, m::MIME"text/html", h::Hist1D)
     println(io, """
     <div style="display: flex;">
         <div style="float:left; margin:5px">$(_svg(h))</div>
-        <div style="float:left; margin:5px; display:flex; justify-content:center; align-items:center; text-overflow:ellipsis;">
-            edges: $(repr(binedges(h), context=:limit => true))<br>
-            bin counts: $(repr(bincounts(h), context=:limit => true))<br>
-            maximum count: $(maximum(bincounts(h)))<br>
-            total count: $(sum(bincounts(h)))
+        <div style="float:left; margin:5px; max-width: 50%; display:flex; justify-content:center; align-items:center;">
+            <ul>
+                <li>edges: $(repr(binedges(h), context=:limit => true))</li>
+                <li>bin counts: $(repr(bincounts(h), context=:limit => true))</li>
+                <li>maximum count: $(maximum(bincounts(h)))</li>
+                <li>total count: $(sum(bincounts(h)))</li>
+            </ul>
         </div>
     </div>
     """)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -205,5 +205,7 @@ end
 @testset "Repr" begin
     h1 = Hist1D(randn(100), -3:3)
     @test all(occursin.(["edges:", "total count:", "bin counts:"], repr(h1)))
+    @test !occursin("<svg", repr(h1))
+    @test all(occursin.(["edges:", "total count:", "bin counts:", "<svg"], repr("text/html", h1)))
 end
 


### PR DESCRIPTION
Closes https://github.com/Moelf/FHist.jl/issues/26.

Implement `show` for `"text/html"` to get:
![image](https://user-images.githubusercontent.com/5760027/129858177-11a84359-97f6-40ad-9e7b-82a58d207280.png)

Despite google and several threads talking about `context=:compact=>true`, I had to dig into `Base.show_vector` to realize it is `:limit`:
`repr(bincounts(h), context=:limit => true)` gives the properly elided string
`"[10, 6, 10, 12, 13, 19, 26, 35, 45, 49 … 2, 3, 6, 4, 1, 3, 0, 0, 0, 1]"`