### PR TITLE
add restrict method

### DIFF
--- a/src/FHist.jl
+++ b/src/FHist.jl
@@ -1,7 +1,7 @@
 module FHist
 
 export Hist1D, binedges, bincounts, bincenters, nbins, integral
-export sample, lookup, cumulative, normalize
+export sample, lookup, cumulative, normalize, restrict
 export unsafe_push!
 
 using StatsBase, RecipesBase, UnicodePlots, Statistics

--- a/src/hist1d.jl
+++ b/src/hist1d.jl
@@ -141,8 +141,7 @@ function Hist1D(A::AbstractVector, r::AbstractRange)
 end
 function Hist1D(A::AbstractVector, edges::AbstractVector)
     if _is_uniform_bins(edges)
-        s = edges[2] - first(edges)
-        r = first(edges):s:last(edges)
+        r = range(first(edges), last(edges), length=length(edges))
         return Hist1D(A, r)
     else
         h = Hist1D(Int; bins=edges)
@@ -166,8 +165,7 @@ function Hist1D(A, wgts::AbstractWeights, r::AbstractRange)
 end
 function Hist1D(A, wgts::AbstractWeights, edges::AbstractVector)
     @inbounds if _is_uniform_bins(edges)
-        s = edges[2] - first(edges)
-        r = first(edges):s:last(edges)
+        r = range(first(edges), last(edges), length=length(edges))
         return Hist1D(A, wgts, r)
     else
         h = Hist1D(eltype(wgts); bins=edges)
@@ -271,18 +269,11 @@ function restrict(h::Hist1D, low=-Inf, high=Inf)
         edgesel[lastidx+1] = 1
     end
 
-    _is_uniform_bins = FHist._is_uniform_bins
     c = bincounts(h)[sel]
     edges = binedges(h)[edgesel]
     sumw2 = h.sumw2[sel]
     if _is_uniform_bins(edges)
-        s = edges[2]-first(edges)
-        # FIXME. Try to do
-        #     x = -3:0.1:3
-        #     x[1]:(x[2]-x[1]):x[end]
-        # and observe we lose the last bin
-        s = round(s; digits=10)
-        edges = first(edges):s:last(edges)
+        edges = range(first(edges), last(edges), length=length(edges))
     end
     Hist1D(Histogram(edges, c), sumw2)
 end

--- a/src/hist1d.jl
+++ b/src/hist1d.jl
@@ -330,6 +330,8 @@ function rebin(h::Hist1D, n::Int=1)
     end
     return Hist1D(Histogram(edges, counts), sumw2)
 end
+rebin(n::Int) = Base.Fix2(rebin, n)
+
 function Base.show(io::IO, h::Hist1D)
     _e = binedges(h)
     if nbins(h) < 50

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -70,6 +70,13 @@ end
     h1 = Hist1D(a, 0:5)
     h2 = Hist1D(fit(Histogram, a, 0:5))
     @test h1 == h2
+
+    # test floating point rounding when
+    # coercing explicit bins into StepRange
+    bins = collect(-3:0.1:3.1)
+    h = Hist1D(rand(100), bins)
+    @test binedges(h) isa AbstractRange
+    @test collect(binedges(h)) == bins
 end
 
 @testset "Normalize" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -207,3 +207,18 @@ end
     @test all(occursin.(["edges:", "total count:", "bin counts:"], repr(h1)))
 end
 
+@testset "Restrict" begin
+    h = Hist1D(randn(500), -5:0.2:5)
+    hleft = restrict(h, -Inf, 0.0)
+    hright = restrict(h, 0.0, Inf)
+
+    @test h == restrict(h)
+    @test restrict(h, -1, 1) == (h |> restrict(-1,1))
+    @test integral(hleft) + integral(hright) == integral(h)
+    @test nbins(hleft) + nbins(hright) == nbins(h)
+    @test sum(hleft.sumw2) + sum(hright.sumw2) == sum(h.sumw2)
+
+    @test all(-1 .<= bincenters(restrict(h,-1,1)) .<= 1)
+    @test_throws AssertionError restrict(h, 10, Inf)
+end
+


### PR DESCRIPTION
Addresses another item in https://github.com/Moelf/FHist.jl/issues/13. Add 
```julia
restrict(h::Hist1D, low=-Inf, high=Inf)
```
and also a curried version for, e.g., `h |> restrict(0.5, 3) |> median`.

![image](https://user-images.githubusercontent.com/5760027/129995648-9bda9aab-d337-4cf4-a85f-5a4bafe83d38.png)