### PR TITLE
speed up filling slightly

### DIFF
--- a/src/hist1d.jl
+++ b/src/hist1d.jl
@@ -98,7 +98,7 @@ end
     r = @inbounds h.hist.edges[1]
     L = length(r) - 1
     binidx = _edge_binindex(r, val)
-    if 1 <= binidx <= L
+    if unsigned(binidx - 1) < L
         @inbounds h.hist.weights[binidx] += wgt
         @inbounds h.sumw2[binidx] += wgt^2
     end

--- a/src/hist2d.jl
+++ b/src/hist2d.jl
@@ -77,7 +77,7 @@ end
     Ly = length(ry) - 1
     binidxx = _edge_binindex(rx, valx)
     binidxy = _edge_binindex(ry, valy)
-    if (1 <= binidxx <= Lx) && (1 <= binidxy <= Ly)
+    if (unsigned(binidxx - 1) < Lx) && (unsigned(binidxy - 1) < Ly)
         @inbounds h.hist.weights[binidxx,binidxy] += wgt
         @inbounds h.sumw2[binidxx,binidxy] += wgt^2
     end


### PR DESCRIPTION
Based on [this stack overflow post](https://stackoverflow.com/questions/17095324/fastest-way-to-determine-if-an-integer-is-between-two-integers-inclusive-with/17095534#17095534), we can speed up single threaded filling by 10% by eliminating a branch, replacing
`1 <= binidx <= L`
with
`unsigned(binidx - 1) < L`

### Before
```julia
julia> @benchmark Hist1D(a, -3:0.1:3)
BechmarkTools.Trial: 1309 samples with 1 evaluations.
 Range (min … max):  3.549 ms …   5.399 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     3.764 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   3.812 ms ± 189.810 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%
```
### After
```julia
julia> @benchmark Hist1D(a, -3:0.1:3)
BechmarkTools.Trial: 1412 samples with 1 evaluations.
 Range (min … max):  3.164 ms …   4.815 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     3.480 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   3.526 ms ± 176.690 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%
```