### PR TITLE
implement overflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,12 @@ julia> Threads.@threads for i in a
 
 julia> h1 == h2
 true
+```
 
-julia> Hist1D(rand(1000),0:0.2:0.9; overflow=true) # clamp overflowing values into range
+Additionally, one can specify `overflow=true` when creating a histogram to clamp out-of-bounds values into 
+the edge bins.
+```julia
+julia> Hist1D(rand(1000),0:0.2:0.9; overflow=true)
               ┌                              ┐
    [0.0, 0.2) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 218
    [0.2, 0.4) ┤▇▇▇▇▇▇▇▇▇▇▇ 183
@@ -47,8 +51,6 @@ edges: 0.0:0.2:0.8
 bin counts: [218, 183, 198, 401]
 total count: 1000
 ```
-
-one can use
 
 ## Speed
 

--- a/README.md
+++ b/README.md
@@ -35,18 +35,31 @@ julia> Threads.@threads for i in a
 
 julia> h1 == h2
 true
+
+julia> Hist1D(rand(1000),0:0.2:0.9; overflow=true) # clamp overflowing values into range
+              ┌                              ┐
+   [0.0, 0.2) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 218
+   [0.2, 0.4) ┤▇▇▇▇▇▇▇▇▇▇▇ 183
+   [0.4, 0.6) ┤▇▇▇▇▇▇▇▇▇▇▇▇ 198
+   [0.6, 0.8) ┤▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇▇ 401
+              └                              ┘
+edges: 0.0:0.2:0.8
+bin counts: [218, 183, 198, 401]
+total count: 1000
 ```
+
+one can use
 
 ## Speed
 
-Single-threaded filling happens at ~250 MHz
+Single-threaded filling happens at almost 300 MHz
 ```julia
 julia> a = randn(10^6);
 
 julia> @benchmark Hist1D(a, -3:0.01:3)
- Range (min … max):  4.040 ms …   5.571 ms  ┊ GC (min … max): 0.00% … 0.00%
- Time  (median):     4.393 ms               ┊ GC (median):    0.00%
- Time  (mean ± σ):   4.460 ms ± 198.070 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%
+ Range (min … max):  3.171 ms …   5.764 ms  ┊ GC (min … max): 0.00% … 0.00%
+ Time  (median):     3.492 ms               ┊ GC (median):    0.00%
+ Time  (mean ± σ):   3.544 ms ± 192.347 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%
 ```
 
 ## Features

--- a/src/FHist.jl
+++ b/src/FHist.jl
@@ -44,8 +44,9 @@ struct Hist2D{T<:Real,E} <: AbstractHistogram{T,2,E}
     hist::Histogram{T,2,E}
     sumw2::Array{Float64, 2}
     hlock::SpinLock
-    function Hist2D(h::Histogram{T,2,E}, sw2 = copy(h.weights)) where {T,E}
-        return new{T,E}(h, sw2, SpinLock())
+    overflow::Bool
+    function Hist2D(h::Histogram{T,2,E}, sw2 = copy(h.weights); overflow=_default_overflow) where {T,E}
+        return new{T,E}(h, sw2, SpinLock(), overflow)
     end
 end
 

--- a/src/FHist.jl
+++ b/src/FHist.jl
@@ -19,6 +19,8 @@ end
     s,s
 end
 
+_sturges(x) = StatsBase.sturges(length(x))
+
 @inline function _is_uniform_bins(A::AbstractVector{T}) where T<:Real
     diffs = diff(A)
     diff1 = first(diffs)

--- a/src/FHist.jl
+++ b/src/FHist.jl
@@ -28,12 +28,15 @@ function _is_uniform_bins(A::AbstractRange{T}) where T<:Real
     true
 end
 
+const _default_overflow = false
+
 struct Hist1D{T<:Real,E} <: AbstractHistogram{T,1,E}
     hist::Histogram{T,1,E}
     sumw2::Array{Float64, 1}
     hlock::SpinLock
-    function Hist1D(h::Histogram{T,1,E}, sw2 = copy(h.weights)) where {T,E}
-        return new{T,E}(h, sw2, SpinLock())
+    overflow::Bool
+    function Hist1D(h::Histogram{T,1,E}, sw2 = copy(h.weights); overflow=_default_overflow) where {T,E}
+        return new{T,E}(h, sw2, SpinLock(), overflow)
     end
 end
 

--- a/src/hist1d.jl
+++ b/src/hist1d.jl
@@ -114,10 +114,11 @@ end
 Base.broadcastable(h::Hist1D) = Ref(h)
 
 """
-    Hist1D(elT::Type{T}=Float64; binedges) where {T}
+    Hist1D(elT::Type{T}=Float64; binedges, overflow) where {T}
 
 Initialize an empty histogram with bin content typed as `T` and bin edges.
-To be used with [`push!`](@ref)
+To be used with [`push!`](@ref). Default overflow behavior (`false`)
+will exclude values that are outside of `binedges`.
 """
 function Hist1D(elT::Type{T}=Float64; bins, overflow=_default_overflow) where {T}
     counts = zeros(elT, length(bins) - 1)
@@ -125,8 +126,8 @@ function Hist1D(elT::Type{T}=Float64; bins, overflow=_default_overflow) where {T
 end
 
 """
-    Hist1D(array, edges::AbstractRange)
-    Hist1D(array, edges::AbstractVector)
+    Hist1D(array, edges::AbstractRange; overflow)
+    Hist1D(array, edges::AbstractVector; overflow)
 
 Create a `Hist1D` with given bin `edges` and vlaues from
 array. Weight for each value is assumed to be 1.
@@ -148,8 +149,8 @@ function Hist1D(A::AbstractVector, edges::AbstractVector; overflow=_default_over
 end
 
 """
-    Hist1D(array, wgts::AbstractWeights, edges::AbstractRange)
-    Hist1D(array, wgts::AbstractWeights, edges::AbstractVector)
+    Hist1D(array, wgts::AbstractWeights, edges::AbstractRange; overflow)
+    Hist1D(array, wgts::AbstractWeights, edges::AbstractVector; overflow)
 
 Create a `Hist1D` with given bin `edges` and vlaues from
 array. `wgts` should have the same `size` as `array`.
@@ -172,8 +173,8 @@ function Hist1D(A, wgts::AbstractWeights, edges::AbstractVector, overflow=_defau
 end
 
 """
-    Hist1D(A::AbstractVector{T}; nbins::Integer=StatsBase.sturges(length(A))) where T
-    Hist1D(A::AbstractVector{T}, wgts::AbstractWeights; nbins::Integer=StatsBase.sturges(length(A))) where T
+    Hist1D(A::AbstractVector{T}; nbins::Integer=_sturges(A), overflow) where T
+    Hist1D(A::AbstractVector{T}, wgts::AbstractWeights; nbins::Integer=_sturges(A), overflow) where T
 
 Automatically determine number of bins based on `Sturges` algo.
 """

--- a/src/hist1d.jl
+++ b/src/hist1d.jl
@@ -177,7 +177,6 @@ end
 
 Automatically determine number of bins based on `Sturges` algo.
 """
-_sturges(x) = StatsBase.sturges(length(x))
 function Hist1D(A::AbstractVector{T}; nbins::Integer=_sturges(A), overflow=_default_overflow) where {T}
     F = float(T)
     lo, hi = minimum(A), maximum(A)

--- a/src/hist2d.jl
+++ b/src/hist2d.jl
@@ -94,10 +94,11 @@ end
 Base.broadcastable(h::Hist2D) = Ref(h)
 
 """
-    Hist2D(elT::Type{T}=Float64; binedges) where {T}
+    Hist2D(elT::Type{T}=Float64; binedges, overflow) where {T}
 
 Initialize an empty histogram with bin content typed as `T` and bin edges.
-To be used with [`push!`](@ref)
+To be used with [`push!`](@ref). Default overflow behavior (`false`)
+will exclude values that are outside of `binedges`.
 """
 function Hist2D(elT::Type{T}=Float64; bins, overflow=_default_overflow) where {T}
     counts = zeros(elT, (length(bins[1]) - 1, length(bins[2])-1))
@@ -105,8 +106,8 @@ function Hist2D(elT::Type{T}=Float64; bins, overflow=_default_overflow) where {T
 end
 
 """
-    Hist2D(tuple, edges::Tuple{AbstractRange,AbstractRange})
-    Hist2D(tuple, edges::Tuple{AbstractVector,AbstractVector})
+    Hist2D(tuple, edges::Tuple{AbstractRange,AbstractRange}; overflow)
+    Hist2D(tuple, edges::Tuple{AbstractVector,AbstractVector}; overflow)
 
 Create a `Hist2D` with given bin `edges` and values from
 a 2-tuple of arrays of x, y values. Weight for each value is assumed to be 1.
@@ -129,8 +130,8 @@ function Hist2D(A::Tuple{AbstractVector,AbstractVector}, edges::Tuple{AbstractVe
 end
 
 """
-    Hist2D(tuple, wgts::AbstractWeights, edges::Tuple{AbstractRange,AbstractRange})
-    Hist2D(tuple, wgts::AbstractWeights, edges::Tuple{AbstractVector,AbstractVector})
+    Hist2D(tuple, wgts::AbstractWeights, edges::Tuple{AbstractRange,AbstractRange}; overflow)
+    Hist2D(tuple, wgts::AbstractWeights, edges::Tuple{AbstractVector,AbstractVector}; overflow)
 
 Create a `Hist2D` with given bin `edges` and values from
 a 2-tuple of arrays of x, y values.
@@ -155,8 +156,8 @@ function Hist2D(A::Tuple{AbstractVector,AbstractVector}, wgts::AbstractWeights, 
 end
 
 """
-    Hist2D(A::AbstractVector{T}; nbins::Tuple{Integer,Integer}) where T
-    Hist2D(A::AbstractVector{T}, wgts::AbstractWeights; nbins::Tuple{Integer,Integer}) where T
+    Hist2D(A::AbstractVector{T}; nbins::Tuple{Integer,Integer}, overflow) where T
+    Hist2D(A::AbstractVector{T}, wgts::AbstractWeights; nbins::Tuple{Integer,Integer}, overflow) where T
 
 Automatically determine number of bins based on `Sturges` algo.
 """

--- a/src/hist2d.jl
+++ b/src/hist2d.jl
@@ -160,7 +160,6 @@ end
 
 Automatically determine number of bins based on `Sturges` algo.
 """
-_sturges(x) = StatsBase.sturges(length(x))
 function Hist2D(A::Tuple{AbstractVector{T},AbstractVector{T}};
         nbins::Tuple{Integer,Integer}=_sturges.(A),
         overflow=_default_overflow,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -369,8 +369,8 @@ end
     b = randn(10^5)
     ϵ = 1e-6
     edges = -3:0.5:3
-    aclip = clamp.(a,first(edges)+ϵ,last(edges)-ϵ)
-    bclip = clamp.(b,first(edges)+ϵ,last(edges)-ϵ)
+    aclip = clamp.(a,nextfloat(first(edges)),prevfloat(last(edges)))
+    bclip = clamp.(b,nextfloat(first(edges)),prevfloat(last(edges)))
     sh1 = fit(Histogram, aclip, edges)
     h1 = Hist1D(a, edges, overflow=true)
     @test h1.hist == sh1
@@ -378,7 +378,7 @@ end
 
     h1 = Hist1D(a, overflow=true)
     before = last(bincounts(h1))
-    push!(h1, last(binedges(h1))+ϵ)
+    push!(h1, nextfloat(last(binedges(h1))))
     after = last(bincounts(h1))
     @test after == before + 1
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -364,3 +364,29 @@ end
     @test_throws AssertionError restrict(h, 10, Inf)
 end
 
+@testset "Overflow" begin
+    a = randn(10^5)
+    b = randn(10^5)
+    ϵ = 1e-6
+    edges = -3:0.5:3
+    aclip = clamp.(a,first(edges)+ϵ,last(edges)-ϵ)
+    bclip = clamp.(b,first(edges)+ϵ,last(edges)-ϵ)
+    sh1 = fit(Histogram, aclip, edges)
+    h1 = Hist1D(a, edges, overflow=true)
+    @test h1.hist == sh1
+    @test h1.sumw2 == bincounts(h1)
+
+    h1 = Hist1D(a, overflow=true)
+    before = last(bincounts(h1))
+    push!(h1, last(binedges(h1))+ϵ)
+    after = last(bincounts(h1))
+    @test after == before + 1
+
+    sh2 = fit(Histogram, (aclip,bclip), (edges,edges))
+    h2 = Hist2D((a,b), (edges,edges), overflow=true)
+    @test h2.hist == sh2
+    @test h2.sumw2 == bincounts(h2)
+    @test integral(project(h2, :x)) == length(aclip)
+    @test rebin(h2, 2).overflow == true
+
+end


### PR DESCRIPTION
Closes https://github.com/Moelf/FHist.jl/issues/16

Todo
- [x] overflow behavior
- [x] 1D
- [x] 2D
- [x] readme
- [x] make sure default speed is the same as before
- [x] unit tests
- [x] docstr

Remaining questions
- ~better name for `overflow`? (`overflow=true` seems meaningless since `overflow` isn't a verb) `include_overflow` is too long. Should it be `clip`/`crop`/`truncate`/`cut`? Polled myself and one other person and the votes are 2 for "keep `overflow` but just make sure  to explain it in the docs"~
- ~default behavior? Right now `overflow=false` (to match `StatsBase.histogram` by default). This would be the least surprising to the user. If they want, it's easy to just `Hist1D(a, 1:3, overflow=true)`.~