### PR TITLE
fix bug with step size

### DIFF
--- a/src/hist1d.jl
+++ b/src/hist1d.jl
@@ -16,7 +16,7 @@ end
 end
 
 @inline function _edge_binindex(r::AbstractRange{<:Integer}, x::Integer)
-    return x - first(r) + 1
+    return (x - first(r))÷step(r) + 1
 end
 
 @inline function _edge_binindex(v::AbstractVector, x::Real)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -100,6 +100,12 @@ end
     h2 = Hist1D(fit(Histogram, a, 0:5))
     @test h1 == h2
 
+    # integer values and integer binning
+    a = floor.(Int,abs.(randn(10^6)))
+    h1 = Hist1D(a, -6:2:6)
+    h2 = Hist1D(fit(Histogram, a, -6:2:6))
+    @test h1 == h2
+
     # test floating point rounding when
     # coercing explicit bins into StepRange
     bins = collect(-3:0.1:3.1)


### PR DESCRIPTION
Closes https://github.com/Moelf/FHist.jl/issues/41

After int-dividing by `step(r)`, we still get the same performance for
```julia
julia> a = randn(10^6);

julia> @benchmark Hist1D(a, -3:3)
BechmarkTools.Trial: 2016 samples with 1 evaluations.
 Range (min … max):  2.323 ms …   4.203 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     2.439 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   2.474 ms ± 131.345 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%
```
so that's nice :)