### PR TITLE
optimize binindex calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,14 @@ total count: 1000
 
 ## Speed
 
-Single-threaded filling happens at almost 300 MHz
+Single-threaded filling happens at almost 0.5 GHz
 ```julia
 julia> a = randn(10^6);
 
 julia> @benchmark Hist1D(a, -3:0.01:3)
- Range (min … max):  3.171 ms …   5.764 ms  ┊ GC (min … max): 0.00% … 0.00%
- Time  (median):     3.492 ms               ┊ GC (median):    0.00%
- Time  (mean ± σ):   3.544 ms ± 192.347 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%
+ Range (min … max):  2.178 ms …   3.697 ms  ┊ GC (min … max): 0.00% … 0.00%
+ Time  (median):     2.335 ms               ┊ GC (median):    0.00%
+ Time  (mean ± σ):   2.383 ms ± 151.177 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%
 ```
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -54,14 +54,14 @@ total count: 1000
 
 ## Speed
 
-Single-threaded filling happens at almost 0.5 GHz
+Single-threaded filling happens at almost 400 MHz
 ```julia
 julia> a = randn(10^6);
 
 julia> @benchmark Hist1D(a, -3:0.01:3)
- Range (min … max):  2.178 ms …   3.697 ms  ┊ GC (min … max): 0.00% … 0.00%
- Time  (median):     2.335 ms               ┊ GC (median):    0.00%
- Time  (mean ± σ):   2.383 ms ± 151.177 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%
+ Range (min … max):  2.591 ms …   4.746 ms  ┊ GC (min … max): 0.00% … 0.00%
+ Time  (median):     2.802 ms               ┊ GC (median):    0.00%
+ Time  (mean ± σ):   2.864 ms ± 195.931 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%
 ```
 
 ## Features

--- a/src/hist1d.jl
+++ b/src/hist1d.jl
@@ -12,8 +12,9 @@ function sample(h::Hist1D; n::Int=1)
 end
 
 @inline function _edge_binindex(r::AbstractRange, x::Real)
-    return Base.unsafe_trunc(Int, round((x - first(r)) * inv(step(r)), RoundDown)) + 1
-    # return floor(Int, (x - first(r)) * inv(step(r))) + 1 # uses safe trunc but fails on -Inf, Inf, NaN
+    return floor(Int, (x - first(r)) * inv(step(r))) + 1
+    # # 20% faster and assigns -Inf, Inf, NaN to typemin(Int64)
+    # return Base.unsafe_trunc(Int, round((x - first(r)) * inv(step(r)), RoundDown)) + 1
 end
 
 @inline function _edge_binindex(r::AbstractRange{<:Integer}, x::Integer)

--- a/src/hist1d.jl
+++ b/src/hist1d.jl
@@ -12,7 +12,8 @@ function sample(h::Hist1D; n::Int=1)
 end
 
 @inline function _edge_binindex(r::AbstractRange, x::Real)
-    return floor(Int, (x - first(r)) * inv(step(r))) + 1
+    return Base.unsafe_trunc(Int, round((x - first(r)) * inv(step(r)), RoundDown)) + 1
+    # return floor(Int, (x - first(r)) * inv(step(r))) + 1 # uses safe trunc but fails on -Inf, Inf, NaN
 end
 
 @inline function _edge_binindex(r::AbstractRange{<:Integer}, x::Integer)

--- a/src/hist1d.jl
+++ b/src/hist1d.jl
@@ -12,7 +12,7 @@ function sample(h::Hist1D; n::Int=1)
 end
 
 @inline function _edge_binindex(r::AbstractRange, x::Real)
-    return floor(Int, (x - first(r)) / step(r)) + 1
+    return floor(Int, (x - first(r)) * inv(step(r))) + 1
 end
 
 @inline function _edge_binindex(r::AbstractRange{<:Integer}, x::Integer)


### PR DESCRIPTION
```diff
-    return floor(Int, (x - first(r)) / step(r)) + 1
+    return floor(Int, (x - first(r)) * inv(step(r))) + 1
```
apparently gives a ~20% speedup for histogram filling (3.1ms -> 2.5ms for randn(10^6)).

_______

If we also did 
```julia
return Base.unsafe_trunc(Int, round((x - first(r)) * inv(step(r)), RoundDown)) + 1
```
we can get another 20% (2.5ms -> 2.05ms)

`unsafe_trunc` avoids a `if $(Tf(typemin(Ti))) <= x < $(Tf(typemax(Ti)))` check. Currently we have
```julia
julia> Hist1D([-Inf,Inf,NaN], -1:0.5:1)
ERROR: InexactError: trunc(Int64, -Inf)
```
and if we used `unsafe_trunc`, we'd have
```julia
julia> Hist1D([-Inf,Inf,NaN], -1:0.5:1)
                ┌                              ┐
   [-1.0, -0.5) ┤ 0
   [-0.5,  0.0) ┤ 0
   [ 0.0,  0.5) ┤ 0
   [ 0.5,  1.0) ┤ 0
                └                              ┘
edges: -1.0:0.5:1.0
bin counts: [0, 0, 0, 0]
total count: 0
```