### PR TITLE
better compact representation

### DIFF
--- a/src/hist1d.jl
+++ b/src/hist1d.jl
@@ -342,15 +342,22 @@ function _svg(h::Hist1D)
 end
 
 function Base.show(io::IO, h::Hist1D)
-    if (nbins(h) < 50) && all(bincounts(h) .>= 0)
-        _e = binedges(h)
-        _h = Histogram(float.(_e), bincounts(h))
-        show(io, UnicodePlots.histogram(_h; width=30, xlabel=""))
+    compact = get(io, :compact, false)
+    if compact
+        print(io, "Hist1D{$(eltype(bincounts(h)))}, ")
+        print(io, "edges=$(repr(binedges(h), context=:limit => true)), ")
+        print(io, "integral=$(integral(h))")
+    else
+        if (nbins(h) < 50) && all(bincounts(h) .>= 0)
+            _e = binedges(h)
+            _h = Histogram(float.(_e), bincounts(h))
+            show(io, UnicodePlots.histogram(_h; width=30, xlabel=""))
+        end
+        println(io)
+        println(io, "edges: ", binedges(h))
+        println(io, "bin counts: ", bincounts(h))
+        print(io, "total count: ", integral(h))
     end
-    println(io)
-    println(io, "edges: ", binedges(h))
-    println(io, "bin counts: ", bincounts(h))
-    print(io, "total count: ", integral(h))
 end
 
 function Base.show(io::IO, m::MIME"text/html", h::Hist1D)

--- a/src/hist2d.jl
+++ b/src/hist2d.jl
@@ -371,15 +371,22 @@ function _svg(h::Hist2D)
 end
 
 function Base.show(io::IO, h::Hist2D)
-    ex, ey = binedges(h)
-    nx, ny = nbins(h)
-    xscale = nx > 1 ? (maximum(ex)-minimum(ex))/(nx-1) : 0.0
-    yscale = ny > 1 ? (maximum(ey)-minimum(ey))/(ny-1) : 0.0
-    show(io, UnicodePlots.heatmap(bincounts(h)'; xscale=xscale, xoffset=minimum(ex), yscale=yscale, yoffset=minimum(ey)))
-    println(io)
-    println(io, "edges: ", binedges(h))
-    println(io, "bin counts: ", bincounts(h))
-    print(io, "total count: ", integral(h))
+    compact = get(io, :compact, false)
+    if compact
+        print(io, "Hist2D{$(eltype(bincounts(h)))}, ")
+        print(io, "edges=$(repr(binedges(h), context=:limit => true)), ")
+        println(io, "integral=$(integral(h))")
+    else
+        ex, ey = binedges(h)
+        nx, ny = nbins(h)
+        xscale = nx > 1 ? (maximum(ex)-minimum(ex))/(nx-1) : 0.0
+        yscale = ny > 1 ? (maximum(ey)-minimum(ey))/(ny-1) : 0.0
+        show(io, UnicodePlots.heatmap(bincounts(h)'; xscale=xscale, xoffset=minimum(ex), yscale=yscale, yoffset=minimum(ey)))
+        println(io)
+        println(io, "edges: ", binedges(h))
+        println(io, "bin counts: ", bincounts(h))
+        print(io, "total count: ", integral(h))
+    end
 end
 
 function Base.show(io::IO, m::MIME"text/html", h::Hist2D)

--- a/src/hist2d.jl
+++ b/src/hist2d.jl
@@ -375,7 +375,7 @@ function Base.show(io::IO, h::Hist2D)
     if compact
         print(io, "Hist2D{$(eltype(bincounts(h)))}, ")
         print(io, "edges=$(repr(binedges(h), context=:limit => true)), ")
-        println(io, "integral=$(integral(h))")
+        print(io, "integral=$(integral(h))")
     else
         ex, ey = binedges(h)
         nx, ny = nbins(h)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -360,6 +360,7 @@ end
         @test all(occursin.(["edges:", "total count:", "bin counts:"], repr(h1)))
         @test !occursin("<svg", repr(h1))
         @test all(occursin.(["edges:", "total count:", "bin counts:", "<svg"], repr("text/html", h1)))
+        @test all(occursin.(["edges=", "integral=", "Hist"], repr(h1, context=:compact=>true)))
     end
 end
 


### PR DESCRIPTION
When `:compact=>true` is set inside `show()`, then use a one-liner representation. Helps for histograms inside a dict, for example. Regular representation via `h`/`show(h)`/`print(h)` is unaffected and still shows the unicode plot.

Before
```julia
julia> d=Dict(
           :h1=>Hist1D(randn(100)),
           :h2=>Hist1D(randn(10^5))*2.5,
           :h3=>Hist2D((rand(100),rand(100)))
       )
Dict{Symbol, AbstractHistogram} with 3 entries:
  :h1 =>                 ┌                              ┐ …
  :h2 =>                 ┌                              ┐ …
  :h3 =>      ┌─────┐ …
```

After
```julia
julia> d=Dict(
           :h1=>Hist1D(randn(100)),
           :h2=>Hist1D(randn(10^5))*2.5,
           :h3=>Hist2D((rand(100),rand(100)))
       )
Dict{Symbol, AbstractHistogram} with 3 entries:
  :h1 => Hist1D{Int64}, edges=-4.0:1.0:3.0, integral=100
  :h2 => Hist1D{Float64}, edges=-4.5:0.5:4.5, integral=250000.0
  :h3 => Hist2D{Int64}, edges=(0.0:0.2:1.0, 0.0:0.2:1.0), integral=100…
```