### PR TITLE
move zero line when there are negative counts

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -356,7 +356,8 @@ end
 
 @testset "Repr" begin
     for h1 in (Hist1D(randn(100), -3:3),
-              Hist2D((randn(10),randn(10)), (-3:3,-3:3)))
+               Hist2D((randn(10),randn(10)), (-3:3,-3:3)),
+               profile(Hist2D((randn(10^5),randn(10^5)), (-3:0.1:3, -5:0.1:5)), :x))
         @test all(occursin.(["edges:", "total count:", "bin counts:"], repr(h1)))
         @test !occursin("<svg", repr(h1))
         @test all(occursin.(["edges:", "total count:", "bin counts:", "<svg"], repr("text/html", h1)))


### PR DESCRIPTION
svg drawing for 1D assumes the minimum count is 0. This is not necessarily true if the histogram is a profile. If there is a bin with a negative "count" then the counts are shifted fully into range and the y=0 line is moved upward.

```julia
h = Hist2D((randn(10^6),randn(10^6)), (-3:0.1:3, -5:0.1:5))
h |> profile(:x)
```
Before
![image](https://user-images.githubusercontent.com/5760027/131944896-72c95c7b-3c64-4e91-ba05-eb4b7c80e74a.png)

After
![image](https://user-images.githubusercontent.com/5760027/131944815-f4c6c923-e730-4cc7-a020-e3b5aff4da08.png)
