### PR TITLE
[don't look inside] specialize on...nthreads

### DIFF
--- a/src/hist1d.jl
+++ b/src/hist1d.jl
@@ -98,11 +98,13 @@ Adding one value at a time into histogram.
 N.B. To append multiple values at once, use broadcasting via
 `push!.(h, [-3.0, -2.9, -2.8])` or `push!.(h, [-3.0, -2.9, -2.8], 2.0)`
 """
-@inline function Base.push!(h::Hist1D{T,E}, val::Real, wgt::Real=1) where {T,E}
-    lock(h)
-    unsafe_push!(h, val, wgt)
-    unlock(h)
-    return nothing
+let (before,after) = Threads.nthreads()>1 ? (:(lock(h)), :(unlock(h))) : (nothing, nothing)
+    @eval @inline function Base.push!(h::Hist1D{T,E}, val::Real, wgt::Real=1) where {T,E}
+        $before
+        unsafe_push!(h, val, wgt)
+        $after
+        return nothing
+    end
 end
 
 @inline function unsafe_push!(h::Hist1D{T,E}, val::Real, wgt::Real=1) where {T,E}

--- a/src/hist1d.jl
+++ b/src/hist1d.jl
@@ -98,13 +98,12 @@ Adding one value at a time into histogram.
 N.B. To append multiple values at once, use broadcasting via
 `push!.(h, [-3.0, -2.9, -2.8])` or `push!.(h, [-3.0, -2.9, -2.8], 2.0)`
 """
-let (before,after) = Threads.nthreads()>1 ? (:(lock(h)), :(unlock(h))) : (nothing, nothing)
-    @eval @inline function Base.push!(h::Hist1D{T,E}, val::Real, wgt::Real=1) where {T,E}
-        $before
-        unsafe_push!(h, val, wgt)
-        $after
-        return nothing
-    end
+_lk, _ulk = Threads.nthreads()>1 ? (:(lock(h)), :(unlock(h))) : (:(), :())
+@eval @inline function Base.push!(h::Hist1D{T,E}, val::Real, wgt::Real=1) where {T,E}
+    $_lk
+    unsafe_push!(h, val, wgt)
+    $_ulk
+    return nothing
 end
 
 @inline function unsafe_push!(h::Hist1D{T,E}, val::Real, wgt::Real=1) where {T,E}

--- a/src/hist2d.jl
+++ b/src/hist2d.jl
@@ -72,13 +72,12 @@ Adding one value at a time into histogram.
 `unsafe_push!` is a faster version of `push!` that is not thread-safe.
 
 """
-let (before,after) = Threads.nthreads()>1 ? (:(lock(h)), :(unlock(h))) : (nothing, nothing)
-    @eval @inline function Base.push!(h::Hist2D{T,E}, valx::Real, valy::Real, wgt::Real=1) where {T,E}
-        $before
-        unsafe_push!(h, valx, valy, wgt)
-        $after
-        return nothing
-    end
+_lk, _ulk = Threads.nthreads()>1 ? (:(lock(h)), :(unlock(h))) : (:(), :())
+@eval @inline function Base.push!(h::Hist2D{T,E}, valx::Real, valy::Real, wgt::Real=1) where {T,E}
+    $_lk
+    unsafe_push!(h, valx, valy, wgt)
+    $_ulk
+    return nothing
 end
 
 @inline function unsafe_push!(h::Hist2D{T,E}, valx::Real, valy::Real, wgt::Real=1) where {T,E}


### PR DESCRIPTION
We have a `lock(h)`/`unlock(h)` in `push!` which just wastes time when the julia instance has 1 thread. Luckily we can change that with only a couple of lines :)

This probably helps everyone who has not aliased `julia` -> `julia -t 4` ;)