### PR TITLE
Inline and optimize `push!()` when one-shot histogramming

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,10 @@ name: CI
 on:
   pull_request:
     branches:
-      - master
+      - main
   push:
     branches:
-      - master
+      - main
     tags: '*'
 jobs:
   test:

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -27,7 +27,6 @@ makedocs(;
     repo="https://github.com/Moelf/FHist.jl/blob/{commit}{path}#L{line}",
     sitename="FHist.jl",
     authors="Jerry Ling",
-    assets=String[],
 )
 
 deploydocs(;

--- a/docs/src/notebooks/makie_plotting.jl
+++ b/docs/src/notebooks/makie_plotting.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.19.5
+# v0.19.32
 
 using Markdown
 using InteractiveUtils
@@ -175,7 +175,7 @@ with_theme(ATLASTHEME) do
 end
 
 # ╔═╡ Cell order:
-# ╟─4cf8f502-eba2-11ec-275f-3f1858e4c2e6
+# ╠═4cf8f502-eba2-11ec-275f-3f1858e4c2e6
 # ╠═82a6fb18-e9c9-450d-9c93-e05bd6cf5859
 # ╠═180e65b9-13db-4b0c-8b16-369b6978cec0
 # ╠═8491f5c3-93b6-4670-8f6e-0d08d7afbf75

--- a/src/hist1d.jl
+++ b/src/hist1d.jl
@@ -140,7 +140,7 @@ Base.broadcastable(h::Hist1D) = Ref(h)
     Hist1D(elT::Type{T}=Float64; bins, overflow) where {T}
 
 Initialize an empty histogram with bin content typed as `T` and bin edges.
-To be used with [`push!`](@ref). Default overflow behavior (`false`)
+To be used with [`Base.push!`](@ref). Default overflow behavior (`false`)
 will exclude values that are outside of `binedges`.
 """
 function Hist1D(elT::Type{T}=Float64; bins, overflow=_default_overflow) where {T}

--- a/src/hist1d.jl
+++ b/src/hist1d.jl
@@ -140,7 +140,7 @@ Base.broadcastable(h::Hist1D) = Ref(h)
     Hist1D(elT::Type{T}=Float64; bins, overflow) where {T}
 
 Initialize an empty histogram with bin content typed as `T` and bin edges.
-To be used with [`Base.push!`](@ref). Default overflow behavior (`false`)
+To be used with `push!` or [`atomic_push!`](@ref). Default overflow behavior (`false`)
 will exclude values that are outside of `binedges`.
 """
 function Hist1D(elT::Type{T}=Float64; bins, overflow=_default_overflow) where {T}

--- a/src/hist2d.jl
+++ b/src/hist2d.jl
@@ -105,7 +105,7 @@ Base.broadcastable(h::Hist2D) = Ref(h)
     Hist2D(elT::Type{T}=Float64; binedges, overflow) where {T}
 
 Initialize an empty histogram with bin content typed as `T` and bin edges.
-To be used with [`Base.push!`](@ref). Default overflow behavior (`false`)
+To be used with `push!` or [`atomic_push!`](@ref). Default overflow behavior (`false`)
 will exclude values that are outside of `binedges`.
 """
 function Hist2D(elT::Type{T}=Float64; bins, overflow=_default_overflow) where {T}

--- a/src/hist2d.jl
+++ b/src/hist2d.jl
@@ -105,7 +105,7 @@ Base.broadcastable(h::Hist2D) = Ref(h)
     Hist2D(elT::Type{T}=Float64; binedges, overflow) where {T}
 
 Initialize an empty histogram with bin content typed as `T` and bin edges.
-To be used with [`push!`](@ref). Default overflow behavior (`false`)
+To be used with [`Base.push!`](@ref). Default overflow behavior (`false`)
 will exclude values that are outside of `binedges`.
 """
 function Hist2D(elT::Type{T}=Float64; bins, overflow=_default_overflow) where {T}

--- a/src/hist3d.jl
+++ b/src/hist3d.jl
@@ -107,7 +107,7 @@ Base.broadcastable(h::Hist3D) = Ref(h)
     Hist3D(elT::Type{T}=Float64; binedges, overflow) where {T}
 
 Initialize an empty histogram with bin content typed as `T` and bin edges.
-To be used with [`push!`](@ref). Default overflow behavior (`false`)
+To be used with [`Base.push!`](@ref). Default overflow behavior (`false`)
 will exclude values that are outside of `binedges`.
 """
 function Hist3D(elT::Type{T}=Float64; bins, overflow=_default_overflow) where {T}

--- a/src/hist3d.jl
+++ b/src/hist3d.jl
@@ -107,7 +107,7 @@ Base.broadcastable(h::Hist3D) = Ref(h)
     Hist3D(elT::Type{T}=Float64; binedges, overflow) where {T}
 
 Initialize an empty histogram with bin content typed as `T` and bin edges.
-To be used with [`Base.push!`](@ref). Default overflow behavior (`false`)
+To be used with `push!` or [`atomic_push!`](@ref). Default overflow behavior (`false`)
 will exclude values that are outside of `binedges`.
 """
 function Hist3D(elT::Type{T}=Float64; bins, overflow=_default_overflow) where {T}


### PR DESCRIPTION
## Before
```julia
julia> @benchmark Hist1D(x, range(-1,2;length=31)) setup=x=rand(10000000)
BenchmarkTools.Trial: 85 samples with 1 evaluation.
 Range (min … max):  42.596 ms … 181.668 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     47.884 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   48.218 ms ±  15.178 ms  ┊ GC (mean ± σ):  0.00% ± 0.00%

  █▅▁
  ███▆▁▃▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▄▃▇▆▄▃▃▁▁▄▁▃▁▁▁▁▁▁▁▁▅▆▆▆▃▁▁▁▃▁▃▄ ▁
  42.6 ms         Histogram: frequency by time         53.7 ms <

 Memory estimate: 1.00 KiB, allocs estimate: 6.
```


## This PR
```julia
julia> @benchmark Hist1D(x, range(-1,2;length=31)) setup=x=rand(10000000)
BenchmarkTools.Trial: 207 samples with 1 evaluation.
 Range (min … max):  12.546 ms …  13.519 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     12.810 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   12.819 ms ± 164.795 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

       ▂▁█▁ ▃ ▃    ▁ ▂▃▅    ▅▁▂  ▁
  ▄▁▄▃▄████▆█▆█▇▇▄▇█▄███▅▅▇▆███▄██▃▅▄▄▄▄▄▄▁▄▁▃▁▁▃▃▁▃▁▁▁▁▁▃▃▁▃▃ ▄
  12.5 ms         Histogram: frequency by time         13.3 ms <

 Memory estimate: 1.00 KiB, allocs estimate: 6.
```

## Compare to [fast-histogram](https://github.com/astrofrog/fast-histogram/) (C backend) and [boost-histogram](https://github.com/scikit-hep/hist) (C++ backend)

```python
In [1]: from hist import Hist

In [7]: import numpy as np

In [8]: x = np.random.random(10_000_000)

In [13]: from fast_histogram import histogram1d

In [12]: %%timeit
    ...: h = Hist.new.Reg(30, -1, 2).Int64()
    ...: h.fill(x)
    ...:
    ...:
21.1 ms ± 71.1 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [14]: %timeit _ = histogram1d(x, range=[-1, 2], bins=30)
13.9 ms ± 53.9 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```