### PR TITLE
Add HDF5 dump/read functionality for Hist1D/2D/3D

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,19 +15,22 @@ StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [weakdeps]
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
+HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 
 [extensions]
 FHistCairoMakieExt = "CairoMakie"
+FHistHDF5Ext = "HDF5"
 FHistMakieExt = "Makie"
 FHistPlotsExt = "Plots"
 
 [compat]
 BayesHistogram = "1.0.7"
+HDF5 = "0.17"
 LinearAlgebra = "1"
-MakieCore = "0.6, 0.7"
 Makie = "0.19, ^0.20.1"
+MakieCore = "0.6, 0.7"
 Measurements = "^2.7"
 RecipesBase = "^1"
 Requires = "^1.3"
@@ -36,8 +39,8 @@ StatsBase = "^0.33, 0.34"
 julia = "1.6"
 
 [extras]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -27,7 +27,7 @@ FHistPlotsExt = "Plots"
 
 [compat]
 BayesHistogram = "1.0.7"
-HDF5 = "0.17"
+HDF5 = "0.16, 0.17"
 LinearAlgebra = "1"
 Makie = "0.19, ^0.20.1"
 MakieCore = "0.6, 0.7"
@@ -44,4 +44,4 @@ Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Test", "HDF5"]

--- a/Project.toml
+++ b/Project.toml
@@ -39,6 +39,7 @@ StatsBase = "^0.33, 0.34"
 julia = "1.6"
 
 [extras]
+HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FHist"
 uuid = "68837c9b-b678-4cd5-9925-8a54edc8f695"
 authors = ["Moelf <proton[at]jling.dev>", "Nick Amin <amin.nj[at]gmail.com>"]
-version = "0.10.5"
+version = "0.10.6"
 
 [deps]
 BayesHistogram = "000d9b38-65fe-4c81-bdb9-69f01f102479"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,6 +2,7 @@
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 FHist = "68837c9b-b678-4cd5-9925-8a54edc8f695"
+HDF5 = "f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f"
 Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Pluto = "c3e4b0f8-55cb-11ea-2926-15256bba5781"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -24,6 +24,7 @@ makedocs(;
         "Introduction" => "index.md",
         "APIs" => "api.md",
         "Writing to `.root`" => "writingtoroot.md",
+        "Writing to `HDF5`" => "writingtohdf5.md",
         "Tutorials" => T,
     ],
     sitename="FHist.jl",

--- a/docs/src/writingtohdf5.md
+++ b/docs/src/writingtohdf5.md
@@ -10,7 +10,7 @@ loaded, the corresponding methods for `h5dumphist` and
 using FHist
 using HDF5
 
-h = Hist1D(rand(1000), -3:0.3:3)
+h = Hist1D(randn(10_000), -3:0.1:3)
 h5dumphist("foo.h5", "some/path/to/myhist", h)
 ```
 

--- a/docs/src/writingtohdf5.md
+++ b/docs/src/writingtohdf5.md
@@ -2,8 +2,8 @@
 
 `FHist.jl` provides an `HDF5.jl` extension to dump and read histograms
 (`Hist1D`, `Hist2D` and `Hist3D`) to HDF5 files. Once the `HDF5` package is
-loaded, the corresponding methods for [`h5dumphist`](@ref) and
-[`h5readhist`](@ref) will become available:
+loaded, the corresponding methods for `h5dumphist` and
+`h5readhist` will become available:
 
 
 ```@example 1

--- a/docs/src/writingtohdf5.md
+++ b/docs/src/writingtohdf5.md
@@ -38,8 +38,6 @@ f = HDF5.File: (read-only) foo.h5
       └─ 📂 to
          └─ 📂 myhist
             ├─ 🏷️ _producer
-            ├─ 🏷️ closed
-            ├─ 🏷️ isdensity
             ├─ 🏷️ nentries
             ├─ 🏷️ overflow
             ├─ 🔢 edges_1

--- a/docs/src/writingtohdf5.md
+++ b/docs/src/writingtohdf5.md
@@ -3,21 +3,29 @@
 `FHist.jl` provides an `HDF5.jl` extension to dump and read histograms
 (`Hist1D`, `Hist2D` and `Hist3D`) to HDF5 files. Once the `HDF5` package is
 loaded, the corresponding methods for `h5dumphist` and
-`h5readhist` will become available:
+`h5readhist` will become available.
 
+Let's create a `Hist1D`:
 
 ```@example 1
 using FHist
 using HDF5
 
 h = Hist1D(randn(10_000), -3:0.1:3)
+```
+
+Now dump it to an HDF5 file:
+
+```@example 1
 h5dumphist("foo.h5", "some/path/to/myhist", h)
 ```
 
 The histogram is now saved in `foo.h5` in the `some/path/to/myhist` group
 including all the meta information needed to be able to recreate it.
 
+Here is how to read it back:
+
 ```@example 1
-h5readhist("foo.h5", "some/path/to/myhist", Hist1D)
+h5readhist("foo.h5", "some/path/to/myhist")
 ```
 

--- a/docs/src/writingtohdf5.md
+++ b/docs/src/writingtohdf5.md
@@ -5,6 +5,11 @@
 loaded, the corresponding methods for `h5dumphist` and
 `h5readhist` will become available.
 
+The HDF5 format specification used in `FHist.jl` for histograms is
+language/library agnostic and easily portable to other libraries. Counts
+(weights, including `sumw2`), edges and other histogram parameters are stored as
+HDF5 datasets or attributes.
+
 Let's create a `Hist1D`:
 
 ```@example 1
@@ -21,9 +26,28 @@ h5dumphist("foo.h5", "some/path/to/myhist", h)
 ```
 
 The histogram is now saved in `foo.h5` in the `some/path/to/myhist` group
-including all the meta information needed to be able to recreate it.
+including all the meta information needed to be able to recreate it. This is how
+it looks like when opening it with `HDF5.jl` (any other HDF5 library will look
+similarly):
 
-Here is how to read it back:
+```
+f = HDF5.File: (read-only) foo.h5
+🗂️ HDF5.File: (read-only) foo.h5
+└─ 📂 some
+   └─ 📂 path
+      └─ 📂 to
+         └─ 📂 myhist
+            ├─ 🏷️ _producer
+            ├─ 🏷️ closed
+            ├─ 🏷️ isdensity
+            ├─ 🏷️ nentries
+            ├─ 🏷️ overflow
+            ├─ 🔢 edges_1
+            ├─ 🔢 sumw2
+            └─ 🔢 weights
+```
+
+Here is how to read it back to an actual `FHist.Hist1D` instance:
 
 ```@example 1
 h5readhist("foo.h5", "some/path/to/myhist")

--- a/docs/src/writingtohdf5.md
+++ b/docs/src/writingtohdf5.md
@@ -1,8 +1,8 @@
 # Write out a histogram to HDF5
 
-`FHist.jl` provides an `HDF5.jl` extension to dump and read histograms
+`FHist.jl` provides an `HDF5.jl` extension to write and read histograms
 (`Hist1D`, `Hist2D` and `Hist3D`) to HDF5 files. Once the `HDF5` package is
-loaded, the corresponding methods for `h5dumphist` and
+loaded, the corresponding methods for `h5writehist` and
 `h5readhist` will become available.
 
 The HDF5 format specification used in `FHist.jl` for histograms is
@@ -19,10 +19,10 @@ using HDF5
 h = Hist1D(randn(10_000), -3:0.1:3)
 ```
 
-Now dump it to an HDF5 file:
+Now write it to an HDF5 file:
 
 ```@example 1
-h5dumphist("foo.h5", "some/path/to/myhist", h)
+h5writehist("foo.h5", "some/path/to/myhist", h)
 ```
 
 The histogram is now saved in `foo.h5` in the `some/path/to/myhist` group

--- a/docs/src/writingtohdf5.md
+++ b/docs/src/writingtohdf5.md
@@ -1,0 +1,23 @@
+# Write out a histogram to HDF5
+
+`FHist.jl` provides an `HDF5.jl` extension to dump and read histograms
+(`Hist1D`, `Hist2D` and `Hist3D`) to HDF5 files. Once the `HDF5` package is
+loaded, the corresponding methods for [`h5dumphist`](@ref) and
+[`h5readhist`](@ref) will become available:
+
+
+```@example 1
+using FHist
+using HDF5
+
+h = Hist1D(rand(1000), -3:0.3:3)
+h5dumphist("foo.h5", "some/path/to/myhist", h)
+```
+
+The histogram is now saved in `foo.h5` in the `some/path/to/myhist` group
+including all the meta information needed to be able to recreate it.
+
+```@example 1
+h5readhist("foo.h5", "some/path/to/myhist", Hist1D)
+```
+

--- a/ext/FHistHDF5Ext.jl
+++ b/ext/FHistHDF5Ext.jl
@@ -1,0 +1,61 @@
+module FHistHDF5Ext
+
+using FHist
+using HDF5, StatsBase, Base.Threads: SpinLock
+
+import FHist: h5readhist, h5dumphist
+
+
+"""
+    function h5dumphist(filename::AbstractString, path::AbstractString, h::Hist1D)
+
+Writes a [`Hist1D`](@ref) instance to an HDF5 file. The histogram can be retrieved
+using [`h5readhist`](@ref).
+
+# Examples
+h = Hist1D(rand(1000), -3:0.3:3)
+h5dumphist("foo.h5", "some/path/to/myhist", h)
+"""
+function h5dumphist(filename::AbstractString, path::AbstractString, h::Hist1D)
+    h5open(filename, "cw") do f
+
+        g = create_group(f, path)
+        write(g, "weights", h.hist.weights)
+        write(g, "sumw2", h.sumw2)
+        write(g, "edges", collect(h.hist.edges[1]))
+        attributes(g)["isdensity"] = h.hist.isdensity
+        attributes(g)["closed"] = string(h.hist.closed)
+        attributes(g)["overflow"] = string(h.overflow)
+        attributes(g)["nentries"] = h.nentries.x
+        attributes(g)["_producer"] = "FHist.jl"
+    end
+    nothing
+end
+
+
+"""
+    function h5readhist(filename::AbstractString, path::AbstractString, H::Type{Hist1D})
+
+Reads a histogram from an HDF5 file which has been dumped using [`h5dumphist`](@ref).
+
+# Examples
+h = h5readhist("foo.h5", "some/path/to/myhist", Hist1D)
+"""
+function h5readhist(filename::AbstractString, path::AbstractString, H::Type{Hist1D})
+    h5open(filename, "r") do f
+        weights = f["$path/weights"][:]
+        edges = f["$path/edges"][:]
+        isdensity = read_attribute(f[path], "isdensity")
+        closed = Symbol(read_attribute(f[path], "closed"))
+
+        hist = Histogram(edges, weights, closed, isdensity)
+
+        sumw2 = f["$path/sumw2"][:]
+        overflow = parse(Bool, read_attribute(f[path], "overflow"))
+        nentries = Base.RefValue{Int}(read_attribute(f[path], "nentries"))
+        H(hist, sumw2, SpinLock(), overflow, nentries)
+    end
+end
+
+
+end

--- a/ext/FHistHDF5Ext.jl
+++ b/ext/FHistHDF5Ext.jl
@@ -1,7 +1,8 @@
 module FHistHDF5Ext
 
 using FHist
-using HDF5, StatsBase, Base.Threads: SpinLock
+using HDF5, StatsBase
+using Base.Threads: SpinLock
 
 import FHist: h5readhist, h5dumphist
 

--- a/ext/FHistHDF5Ext.jl
+++ b/ext/FHistHDF5Ext.jl
@@ -4,20 +4,20 @@ using FHist
 using HDF5, StatsBase
 using Base.Threads: SpinLock
 
-import FHist: h5readhist, h5dumphist
+import FHist: h5readhist, h5writehist
 
 
 """
-    function h5dumphist(filename::AbstractString, path::AbstractString, h::Hist1D)
+    function h5writehist(filename::AbstractString, path::AbstractString, h::Hist1D)
 
 Writes a [`Hist1D`](@ref) instance to an HDF5 file. The histogram can be retrieved
 using [`h5readhist`](@ref).
 
 # Examples
 h = Hist1D(rand(1000), -3:0.3:3)
-h5dumphist("foo.h5", "some/path/to/myhist", h)
+h5writehist("foo.h5", "some/path/to/myhist", h)
 """
-function h5dumphist(filename::AbstractString, path::AbstractString, h::Union{Hist1D, Hist2D, Hist3D})
+function h5writehist(filename::AbstractString, path::AbstractString, h::Union{Hist1D, Hist2D, Hist3D})
     h5open(filename, "cw") do f
         g = create_group(f, path)
         write(g, "weights", h.hist.weights)
@@ -39,8 +39,8 @@ end
     function h5readhist(filename::AbstractString, path::AbstractString [, H::Type{<: Union{Hist1D, Hist2D, Hist3D}}])
     function h5readhist(f::HDF5.File, path::AbstractString [, H::Type{<: Union{Hist1D, Hist2D, Hist3D}}])
 
-Reads a histogram from an HDF5 file which has been dumped using
-[`h5dumphist`](@ref). The type parameter is optional.
+Reads a histogram from an HDF5 file which has been written using
+[`h5writehist`](@ref). The type parameter is optional.
 
 # Examples
 h = h5readhist("foo.h5", "some/path/to/myhist")

--- a/ext/FHistHDF5Ext.jl
+++ b/ext/FHistHDF5Ext.jl
@@ -25,8 +25,6 @@ function h5writehist(filename::AbstractString, path::AbstractString, h::Union{Hi
         for (dim, edges) in enumerate(h.hist.edges)
             write(g, "edges_$dim", collect(edges))
         end
-        attributes(g)["isdensity"] = h.hist.isdensity
-        attributes(g)["closed"] = string(h.hist.closed)
         attributes(g)["overflow"] = string(h.overflow)
         attributes(g)["nentries"] = h.nentries.x
         attributes(g)["_producer"] = "FHist.jl"
@@ -66,10 +64,8 @@ function h5readhist(f::HDF5.File, path::AbstractString, H::Type{<: Union{Hist1D,
     weights = _read_dset(f["$path/weights"], H)
     dims = parse(Int, match(r"\d+", string(H)).match)
     edges = tuple([f["$path/edges_$dim"][:] for dim in 1:dims]...)
-    isdensity = read_attribute(f[path], "isdensity")
-    closed = Symbol(read_attribute(f[path], "closed"))
 
-    hist = Histogram(edges, weights, closed, isdensity)
+    hist = Histogram(edges, weights)
 
     sumw2 = _read_dset(f["$path/sumw2"], H)
     overflow = parse(Bool, read_attribute(f[path], "overflow"))

--- a/ext/FHistHDF5Ext.jl
+++ b/ext/FHistHDF5Ext.jl
@@ -17,13 +17,14 @@ using [`h5readhist`](@ref).
 h = Hist1D(rand(1000), -3:0.3:3)
 h5dumphist("foo.h5", "some/path/to/myhist", h)
 """
-function h5dumphist(filename::AbstractString, path::AbstractString, h::Hist1D)
+function h5dumphist(filename::AbstractString, path::AbstractString, h::Union{Hist1D, Hist2D, Hist3D})
     h5open(filename, "cw") do f
-
         g = create_group(f, path)
         write(g, "weights", h.hist.weights)
         write(g, "sumw2", h.sumw2)
-        write(g, "edges", collect(h.hist.edges[1]))
+        for (dim, edges) in enumerate(h.hist.edges)
+            write(g, "edges_$dim", collect(edges))
+        end
         attributes(g)["isdensity"] = h.hist.isdensity
         attributes(g)["closed"] = string(h.hist.closed)
         attributes(g)["overflow"] = string(h.overflow)
@@ -42,21 +43,26 @@ Reads a histogram from an HDF5 file which has been dumped using [`h5dumphist`](@
 # Examples
 h = h5readhist("foo.h5", "some/path/to/myhist", Hist1D)
 """
-function h5readhist(filename::AbstractString, path::AbstractString, H::Type{Hist1D})
+function h5readhist(filename::AbstractString, path::AbstractString, H::Type{<: Union{Hist1D, Hist2D, Hist3D}})
     h5open(filename, "r") do f
-        weights = f["$path/weights"][:]
-        edges = f["$path/edges"][:]
+        weights = _read_dset(f["$path/weights"], H)
+        dims = parse(Int, match(r"\d+", string(H)).match)
+        edges = tuple([f["$path/edges_$dim"][:] for dim in 1:dims]...)
         isdensity = read_attribute(f[path], "isdensity")
         closed = Symbol(read_attribute(f[path], "closed"))
 
         hist = Histogram(edges, weights, closed, isdensity)
 
-        sumw2 = f["$path/sumw2"][:]
+        sumw2 = _read_dset(f["$path/sumw2"], H)
         overflow = parse(Bool, read_attribute(f[path], "overflow"))
         nentries = Base.RefValue{Int}(read_attribute(f[path], "nentries"))
         H(hist, sumw2, SpinLock(), overflow, nentries)
     end
 end
+
+_read_dset(d::HDF5.Dataset, ::Type{Hist1D}) = d[:]
+_read_dset(d::HDF5.Dataset, ::Type{Hist2D}) = d[:, :]
+_read_dset(d::HDF5.Dataset, ::Type{Hist3D}) = d[:, :, :]
 
 
 end

--- a/src/FHist.jl
+++ b/src/FHist.jl
@@ -30,10 +30,10 @@ for (H, N) in ((:Hist1D, 1), (:Hist2D, 2), (:Hist3D, 3))
         hlock::SpinLock
         overflow::Bool
         nentries::Base.RefValue{Int}
-        function $H(h::Histogram{T,$N,E}, sw2::AbstractArray{<:Real, $N} = copy(h.weights), nentries=sum(h.weights); overflow=_default_overflow) where {T,E}
-            isinteger(nentries) || @warn "Weights was probably used but StatsBase.Histogram doesn't record # of entries"
-            return new{T,E}(h, sw2, SpinLock(), overflow, Ref(round(Int, nentries)))
-        end
+    end
+    @eval function $H(h::Histogram{T,$N,E}, sw2::AbstractArray{<:Real, $N} = copy(h.weights), nentries=sum(h.weights); overflow=_default_overflow) where {T,E}
+        isinteger(nentries) || @warn "Weights was probably used but StatsBase.Histogram doesn't record # of entries"
+        return $H{T,E}(h, sw2, SpinLock(), overflow, Ref(round(Int, nentries)))
     end
 end
 
@@ -57,6 +57,9 @@ function ratiohist! end
 
 function statbox! end
 function collabtext! end
+
+function h5dumphist end
+function h5readhist end
 
 function __init__()
 

--- a/src/FHist.jl
+++ b/src/FHist.jl
@@ -58,6 +58,7 @@ function ratiohist! end
 function statbox! end
 function collabtext! end
 
+export h5dumphist, h5readhist
 function h5dumphist end
 function h5readhist end
 

--- a/src/FHist.jl
+++ b/src/FHist.jl
@@ -67,6 +67,7 @@ function __init__()
     @static if !isdefined(Base, :get_extension)
         @require Plots="91a5bcdd-55d7-5caf-9e0b-520d859cae80" include("../ext/FHistPlotsExt.jl")
         @require Makie="ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a" include("../ext/FHistMakieExt.jl")
+        @require HDF5="f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f" include("../ext/FHistHDF5.jl")
     end
     
 end

--- a/src/FHist.jl
+++ b/src/FHist.jl
@@ -58,8 +58,8 @@ function ratiohist! end
 function statbox! end
 function collabtext! end
 
-export h5dumphist, h5readhist
-function h5dumphist end
+export h5writehist, h5readhist
+function h5writehist end
 function h5readhist end
 
 function __init__()

--- a/src/FHist.jl
+++ b/src/FHist.jl
@@ -67,7 +67,7 @@ function __init__()
     @static if !isdefined(Base, :get_extension)
         @require Plots="91a5bcdd-55d7-5caf-9e0b-520d859cae80" include("../ext/FHistPlotsExt.jl")
         @require Makie="ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a" include("../ext/FHistMakieExt.jl")
-        @require HDF5="f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f" include("../ext/FHistHDF5.jl")
+        @require HDF5="f67ccb44-e63f-5c2f-98bd-6dc0ccc4ba2f" include("../ext/FHistHDF5Ext.jl")
     end
     
 end

--- a/test/hdf5.jl
+++ b/test/hdf5.jl
@@ -11,10 +11,22 @@ using Test, FHist, HDF5
     h5dumphist(fname, "a/h2", h2)
     h5dumphist(fname, "a/b/h3", h3)
     h5dumphist(fname, "a/b/c/h3_int", h3_int)
+
+    # Explicit type specifications
     h1_from_h5 = h5readhist(fname, "h1", Hist1D)
     h2_from_h5 = h5readhist(fname, "a/h2", Hist2D)
     h3_from_h5 = h5readhist(fname, "a/b/h3", Hist3D)
     h3_int_from_h5 = h5readhist(fname, "a/b/c/h3_int", Hist3D)
+    @test h1 == h1_from_h5
+    @test h2 == h2_from_h5
+    @test h3 == h3_from_h5
+    @test h3_int == h3_int_from_h5
+
+    # Without type specification
+    h1_from_h5 = h5readhist(fname, "h1")
+    h2_from_h5 = h5readhist(fname, "a/h2")
+    h3_from_h5 = h5readhist(fname, "a/b/h3")
+    h3_int_from_h5 = h5readhist(fname, "a/b/c/h3_int")
     @test h1 == h1_from_h5
     @test h2 == h2_from_h5
     @test h3 == h3_from_h5

--- a/test/hdf5.jl
+++ b/test/hdf5.jl
@@ -12,6 +12,11 @@ using Test, FHist, HDF5
     h5writehist(fname, "a/b/h3", h3)
     h5writehist(fname, "a/b/c/h3_int", h3_int)
 
+    h5open(fname) do f
+        version = VersionNumber(read_attribute(f["h1"], "_h5hist_version"))
+        @test v"1.0" == version
+    end
+
     # Explicit type specifications
     h1_from_h5 = h5readhist(fname, "h1", Hist1D)
     h2_from_h5 = h5readhist(fname, "a/h2", Hist2D)

--- a/test/hdf5.jl
+++ b/test/hdf5.jl
@@ -7,10 +7,10 @@ using Test, FHist, HDF5
     h2 = Hist2D((rand(10), rand(10)), (0:0.1:1, 0:0.2:1))
     h3 = Hist3D((rand(10), rand(10), rand(10)), (0:0.1:1, 0:0.2:1, 0:0.3:1))
     h3_int = Hist3D((rand(1:10, 10), rand(1:5, 10), rand(1:9999, 10)), (0:10, 0:5, 0:3); overflow=true)
-    h5dumphist(fname, "h1", h1)
-    h5dumphist(fname, "a/h2", h2)
-    h5dumphist(fname, "a/b/h3", h3)
-    h5dumphist(fname, "a/b/c/h3_int", h3_int)
+    h5writehist(fname, "h1", h1)
+    h5writehist(fname, "a/h2", h2)
+    h5writehist(fname, "a/b/h3", h3)
+    h5writehist(fname, "a/b/c/h3_int", h3_int)
 
     # Explicit type specifications
     h1_from_h5 = h5readhist(fname, "h1", Hist1D)

--- a/test/hdf5.jl
+++ b/test/hdf5.jl
@@ -1,0 +1,22 @@
+using Test, FHist, HDF5
+
+
+@testset "HDF5 I/O" begin
+    fname = tempname()
+    h1 = Hist1D(rand(10), 0:0.1:1)
+    h2 = Hist2D((rand(10), rand(10)), (0:0.1:1, 0:0.2:1))
+    h3 = Hist3D((rand(10), rand(10), rand(10)), (0:0.1:1, 0:0.2:1, 0:0.3:1))
+    h3_int = Hist3D((rand(1:10, 10), rand(1:5, 10), rand(1:9999, 10)), (0:10, 0:5, 0:3); overflow=true)
+    h5dumphist(fname, "h1", h1)
+    h5dumphist(fname, "a/h2", h2)
+    h5dumphist(fname, "a/b/h3", h3)
+    h5dumphist(fname, "a/b/c/h3_int", h3_int)
+    h1_from_h5 = h5readhist(fname, "h1", Hist1D)
+    h2_from_h5 = h5readhist(fname, "a/h2", Hist2D)
+    h3_from_h5 = h5readhist(fname, "a/b/h3", Hist3D)
+    h3_int_from_h5 = h5readhist(fname, "a/b/c/h3_int", Hist3D)
+    @test h1 == h1_from_h5
+    @test h2 == h2_from_h5
+    @test h3 == h3_from_h5
+    @test h3_int == h3_int_from_h5
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using FHist, StatsBase, Statistics
+using FHist, StatsBase, Statistics, HDF5
 using Test
 
 @testset "The basics" begin
@@ -602,3 +602,5 @@ end
     @test nbins(hlefty)[2] + nbins(hrighty)[2] == nbins(h)[2]
     @test sum(hlefty.sumw2) + sum(hrighty.sumw2) == sum(h.sumw2)
 end
+
+include("hdf5.jl")


### PR DESCRIPTION
This PR allows dumping and reading to/from HDF5 files:

```julia
julia> using FHist

julia> h5dumphist
h5dumphist (generic function with 0 methods)

julia> using HDF5
[ Info: Precompiling FHistHDF5Ext [a227ba34-7673-5508-8138-4d59e86345cc]

julia> h = Hist1D(rand(1000), -3:0.3:3)
edges: -3.0:0.3:3.0
bin counts: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 311, 301, 295, 93, 0, 0, 0, 0, 0, 0]
total count: 1000

julia> h5dumphist("foo.h5", "some/path/to/myhist", h)

julia> h5readhist("foo.h5", "some/path/to/myhist", Hist1D)
edges: [-3.0, -2.7, -2.4, -2.1, -1.8, -1.5, -1.2, -0.9, -0.6, -0.3  …  0.3, 0.6, 0.9, 1.2, 1.5, 1.8, 2.1, 2.4, 2.7, 3.0]
bin counts: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 311, 301, 295, 93, 0, 0, 0, 0, 0, 0]
total count: 1000
```