### PR TITLE
h5hist: write overflow as boolean but still support string

### DIFF
--- a/ext/FHistHDF5Ext.jl
+++ b/ext/FHistHDF5Ext.jl
@@ -29,7 +29,7 @@ function h5writehist(filename::AbstractString, path::AbstractString, h::Union{Hi
             write(g, "edges_$dim", collect(edges))
         end
         attributes(g)["overflow"] = h.overflow
-        attributes(g)["nentries"] = h.nentries.x
+        attributes(g)["nentries"] = h.nentries[]
         attributes(g)["_producer"] = "FHist.jl"
         attributes(g)["_h5hist_version"] = string(CURRENT_H5HIST_VERSION)
     end

--- a/ext/FHistHDF5Ext.jl
+++ b/ext/FHistHDF5Ext.jl
@@ -7,7 +7,7 @@ using Base.Threads: SpinLock
 import FHist: h5readhist, h5writehist
 
 const CURRENT_H5HIST_VERSION = v"1.1"
-const SUPPORTED_H5HIST_VERSIONS = [v"1.1"]
+const SUPPORTED_H5HIST_VERSIONS = [v"1.0", v"1.1"]
 
 
 """
@@ -67,7 +67,7 @@ end
 function h5readhist(f::HDF5.File, path::AbstractString, H::Type{<: Union{Hist1D, Hist2D, Hist3D}})
     version = VersionNumber(read_attribute(f[path], "_h5hist_version"))
     version >= v"2" && error("h5hist $(version) is not supported")
-    version > v"1" && @warn """
+    version > v"1.1" && @warn """
         h5hist $(version) is higher than the currently supperted one, some features might be missing.
         Supported versions: $(join(SUPPORTED_H5HIST_VERSIONS, ", "))
     """

--- a/test/hdf5.jl
+++ b/test/hdf5.jl
@@ -14,7 +14,7 @@ using Test, FHist, HDF5
 
     h5open(fname) do f
         version = VersionNumber(read_attribute(f["h1"], "_h5hist_version"))
-        @test v"1.1" == version
+        @test v"1.0" == version
     end
 
     # Explicit type specifications

--- a/test/hdf5.jl
+++ b/test/hdf5.jl
@@ -14,7 +14,7 @@ using Test, FHist, HDF5
 
     h5open(fname) do f
         version = VersionNumber(read_attribute(f["h1"], "_h5hist_version"))
-        @test v"1.0" == version
+        @test v"1.1" == version
     end
 
     # Explicit type specifications


### PR DESCRIPTION
I totally overlooked that `overflow` is stored as string, although the type os `Bool` which is perfectly fine in attributes.

I think we should clean that up but it's a bit embarrassing that we already need v1.1 for the format spec 🙈 On the other hand, that's what is meant for...

This PR still supports strings as `overflow` but now writes `Bool`, which cannot be read with `FHist.jl v0.10.6` without a warning (technically it's probably more likely a v2.0, but let's not exaggerate it?)

I am also not 100% happy with the version checking yet, I guess I need a tea first, it was a very short night ;)