### PR TITLE
Remove obsolete FHistCairoMakieExt ref

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "FHist"
 uuid = "68837c9b-b678-4cd5-9925-8a54edc8f695"
 authors = ["Moelf <proton[at]jling.dev>", "Nick Amin <amin.nj[at]gmail.com>"]
-version = "0.10.7"
+version = "0.10.8"
 
 [deps]
 BayesHistogram = "000d9b38-65fe-4c81-bdb9-69f01f102479"

--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,6 @@ Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 
 [extensions]
-FHistCairoMakieExt = "CairoMakie"
 FHistHDF5Ext = "HDF5"
 FHistMakieExt = "Makie"
 FHistPlotsExt = "Plots"


### PR DESCRIPTION
I think this was forgoten in https://github.com/Moelf/FHist.jl/commit/8240850aabc6a0aee03fea5b2701fcb7fc23765c

Fixes #97 