### PR TITLE
Better (actually correct) error message for rebin

### DIFF
--- a/src/hist1d.jl
+++ b/src/hist1d.jl
@@ -311,7 +311,7 @@ The returned histogram will have `nbins(h)/n` bins.
 function rebin(h::Hist1D, n::Int=1)
     if nbins(h) % n != 0
         rebin_values = join(sort(collect(valid_rebin_values(h))), ", ", " or ")
-        error("Invalid rebin value ($n) for a 1D histogram with $(nbins(h)) bins. It has to be a multiple of $(rebin_values)")
+        error("Invalid rebin value ($n) for a 1D histogram with $(nbins(h)) bins. It has to be a power of $(rebin_values)")
     end
     p = x->Iterators.partition(x, n)
     counts = sum.(p(bincounts(h)))

--- a/src/hist2d.jl
+++ b/src/hist2d.jl
@@ -240,7 +240,7 @@ function rebin(h::Hist2D, nx::Int=1, ny::Int=nx)
     sx, sy = nbins(h)
     if !(sx % nx == sy % ny == 0)
         rebin_values_x, rebin_values_y = map(x->join(sort(collect(x)), ", ", " or "), valid_rebin_values(h))
-        error("Invalid rebin values (nx: $nx, ny: $ny) for a 2D histogram with $(nbins(h)) bins. They have to be a multple of nx: $(rebin_values_x) and ny: $(rebin_values_y)")
+        error("Invalid rebin values (nx: $nx, ny: $ny) for a 2D histogram with $(nbins(h)) bins. They have to be powers of nx: $(rebin_values_x) and ny: $(rebin_values_y)")
     end
     p1d = (x,n)->Iterators.partition(x, n)
     p2d = x->(x[i:i+(nx-1),j:j+(ny-1)] for i=1:nx:sx, j=1:ny:sy)


### PR DESCRIPTION
It says the rebinning factor must be a "multiple of ...", but "power of" is correct.