### PR TITLE
fix bin edges for 2D Makie histograms

### DIFF
--- a/ext/FHistMakieExt.jl
+++ b/ext/FHistMakieExt.jl
@@ -183,7 +183,7 @@ Makie.MakieCore.plottype(::Hist2D) = Heatmap
 function Makie.convert_arguments(P::Type{<:Heatmap}, h2d::Hist2D)
     counts = bincounts(h2d)
     z = zero(eltype(counts))
-    convert_arguments(P, bincenters(h2d)..., replace(counts, z => NaN))
+    convert_arguments(P, binedges(h2d)..., replace(counts, z => NaN))
 end
 
 """


### PR DESCRIPTION
When plotting 2D histograms with variable bin width, the bin edges are slightly misaligned as currently bin centres are passed. E.g. the following code is currently plotting:
```
xy= randn(1000,2);
xb = [-4;-1:1;4]
yb = [-4;-1:1;4]
h = Hist2D((xy[:,1],xy[:,2]); binedges=(xb,yb))
plot(h; figure=(; size=(300,300)), axis=(; limits=(-3,3,-3,3)))
```
![image](https://github.com/Moelf/FHist.jl/assets/94967300/0b199567-14f1-4a73-b01b-63949ed3985a)
While it should plot this instead:
![image](https://github.com/Moelf/FHist.jl/assets/94967300/f6436642-0683-4307-9395-86c20f90bee4)
