### PR TITLE
Fix edge case in plotting for empty bins in logscale

### DIFF
--- a/ext/FHistMakieExt.jl
+++ b/ext/FHistMakieExt.jl
@@ -112,7 +112,10 @@ function Makie.convert_arguments(P::Type{<:Stairs}, h::Hist1D)
     edges = binedges(h)
     phantomedge = edges[end] # to bring step back to baseline
     bot = eps()
-    convert_arguments(P, vcat(edges, phantomedge), vcat(bot, bincounts(h), bot))
+    bc = bincounts(h)
+    z = zero(eltype(bc))
+    nonzero_bincounts = replace(bc, z => bot)
+    convert_arguments(P, vcat(edges, phantomedge), vcat(bot, nonzero_bincounts, bot))
 end
 Makie.convert_arguments(P::Type{<:Scatter}, h::Hist1D) = convert_arguments(P, bincenters(h), bincounts(h))
 Makie.convert_arguments(P::Type{<:BarPlot}, h::Hist1D) = convert_arguments(P, bincenters(h), bincounts(h))

--- a/src/MakieThemes.jl
+++ b/src/MakieThemes.jl
@@ -10,8 +10,8 @@ end
 """
 const ATLASTHEME = MakieCore.Attributes(
       Axis = (
-              xtickalign=1, ytickalign=1, 
-              xticksmirrored=1, yticksmirrored=1,
+              xtickalign=true, ytickalign=true,
+              xticksmirrored=true, yticksmirrored=true,
               xminortickalign=1, yminortickalign=1,
               xticksize=10, yticksize=10,
               xminorticksize=6, yminorticksize=6,


### PR DESCRIPTION
The problem was that Makie refuse to render the binedge leading to 0 under y logscale.

We replace any zero value in the `bincounts` with `eps()` since they shouldn't be visually
distinguishible for any practical purpose.

Fixs #109
