### PR TITLE
add log safe Makie

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,13 +5,11 @@ version = "0.11.4"
 
 [deps]
 BayesHistogram = "000d9b38-65fe-4c81-bdb9-69f01f102479"
-CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MakieCore = "20f20a25-4f0e-4fdf-b5d1-57303727442b"
 Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
-Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 

--- a/Project.toml
+++ b/Project.toml
@@ -5,11 +5,13 @@ version = "0.11.4"
 
 [deps]
 BayesHistogram = "000d9b38-65fe-4c81-bdb9-69f01f102479"
+CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MakieCore = "20f20a25-4f0e-4fdf-b5d1-57303727442b"
 Measurements = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
+Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 

--- a/ext/FHistMakieExt.jl
+++ b/ext/FHistMakieExt.jl
@@ -119,7 +119,7 @@ function Makie.convert_arguments(P::Type{<:Stairs}, h::Hist1D)
 end
 
 function Makie.convert_arguments(P::Type{<:Scatter}, h::Hist1D)
-    bc = cpopy(bincounts(h))
+    bc = copy(bincounts(h))
     SAFE_LOG[] && _clip_counts!(bc)
     convert_arguments(P, bincenters(h), bc)
 end  

--- a/src/FHist.jl
+++ b/src/FHist.jl
@@ -218,6 +218,7 @@ include("./arithmatics.jl")
 using MakieCore
 include("./MakieThemes.jl")
 export ATLASTHEME, stackedhist, stackedhist!, ratiohist, ratiohist!
+include("./SafeLog.jl")
 
 function stackedhist end
 function stackedhist! end

--- a/src/SafeLog.jl
+++ b/src/SafeLog.jl
@@ -1,0 +1,48 @@
+module SafeLog
+
+const SAFE_LOG = Ref(false)
+
+"""
+    set_safe_log(x::Bool)
+
+Turn on/off SAFE_LOG, to plot histograms without/with negative values. By default is `false`.
+"""
+function set_safe_log(x::Bool)
+    SAFE_LOG[]=x
+end
+
+
+"""
+    _clip_for_log(c_vec)
+
+Internal fuction to clip counts of histogram. 
+"""
+function _clip_counts!(c_vec)
+    min_positive = eps()
+    @. c_vec = max(c_vec, min_positive)
+end
+
+
+"""
+    _clip_counts!(c_vec,el_vec, eh_vec)
+
+Internal fuction to clip counts and errors of histogram. 
+"""
+function _clip_counts!(c_vec, el_vec, eh_vec)
+    
+    # Set the clipping, and make copy of starting counts
+    min_positive = eps()
+    c_vec_def = copy(c_vec)
+
+    # Clip bin counts
+    @. c_vec = max(c_vec, min_positive)
+
+    # clip lower errors
+    mask =  c_vec - el_vec .< min_positive
+    el_vec[mask] = c_vec[mask] .- min_positive
+
+    # clip higher errors
+    @. eh_vec = eh_vec - (c_vec - c_vec_def)
+end
+ 
+end

--- a/src/SafeLog.jl
+++ b/src/SafeLog.jl
@@ -42,7 +42,7 @@ function _clip_counts!(c_vec, el_vec, eh_vec)
     el_vec[mask] = c_vec[mask] .- min_positive
 
     # clip higher errors
-    @. eh_vec = eh_vec - (c_vec - c_vec_def)
+    @. eh_vec = max(eh_vec - (c_vec - c_vec_def), min_positive)
 end
  
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -625,10 +625,10 @@ end
     bc = copy(bincounts(h))
     err_up = copy(binerrors(h))
     err_dn = copy(binerrors(h))
-    FHist.SafeLog._clip_counts!(bc)
+    FHist.SafeLog._clip_counts!(bc, err_dn, err_up)
     @test all(@. bc >= eps())
-    @test all(@. bc - err_dn >= eps())
-    @test all(@. bc + err_up == bincounts(h) + binerrors(h))
+    @test all(@. bc - err_dn >= 0)
+    @test all( abs.(bc .+ err_up  .- (bincounts(h) .+ binerrors(h))) .<= eps())
 
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -612,4 +612,24 @@ end
     @test all(significance(h1,h2) .≈ (9.839916447569484, 0.30998654607114046))
 end
 
+@testset "SafeLog" begin
+
+    FHist.SafeLog.set_safe_log(true)
+    @test FHist.SafeLog.SAFE_LOG[] == true
+    
+    h = Hist1D(bincounts=[0.5,-0.5],binedges=[1,2,3],sumw2=[1.01,1.01])
+    bc = copy(bincounts(h))
+    FHist.SafeLog._clip_counts!(bc)
+    @test all(bc .>= eps())
+
+    bc = copy(bincounts(h))
+    err_up = copy(binerrors(h))
+    err_dn = copy(binerrors(h))
+    FHist.SafeLog._clip_counts!(bc)
+    @test all(@. bc >= eps())
+    @test all(@. bc - err_dn >= eps())
+    @test all(@. bc + err_up == bincounts(h) + binerrors(h))
+
+end
+
 include("hdf5.jl")


### PR DESCRIPTION
This is an attempt at making the MakieExt safe for plotting in log scale. But keeping the option to disable such a feature, and have histograms with negative values. Tagging @Moelf :heart_eyes: 
  