### PR TITLE
`clamp_errors` options for Makie Errorbars and `clamp_bincounts` for histograms

### DIFF
--- a/docs/src/notebooks/makie_plotting.jl
+++ b/docs/src/notebooks/makie_plotting.jl
@@ -175,8 +175,8 @@ md"""## Clamping/clipping bincounts and errorbars
 
 | - | clamp_bincounts = false (default) | clamp_bincounts = true |
 | --- | -------------------------------- | -------------------------------- |
-| clamp_errors = false | - | - |
-| clamp_errors = true (default) | - | - |
+| clamp_errors = false | ![image](https://github.com/Moelf/FHist.jl/assets/5306213/e8571535-0d5a-47f1-97a5-efd223f5973b) | Don't do this |
+| clamp_errors = true (default) | ![image](https://github.com/Moelf/FHist.jl/assets/5306213/a29d9dee-481f-4604-bcc2-113125ede1e3) | ![image](https://github.com/Moelf/FHist.jl/assets/5306213/7004f258-5aa9-4d9c-b303-116fec79b17a) |
 
 !!! note
     `clamp_bincounts` only works with `stairs()` and `barplot()` directly (does not work with `stephist(), hist()` for the moment.
@@ -224,7 +224,7 @@ end
 
 # ╔═╡ fae56f0f-bac4-4dea-b33c-d45e6f3b51fc
 let
-    f, a, p = stackedhist([h1, h1 ]; error_color=Pattern('/'))
+    f, a, p = stackedhist([h1, h1]; error_color=Pattern('/'))
 	f
 end
 

--- a/docs/src/notebooks/makie_plotting.jl
+++ b/docs/src/notebooks/makie_plotting.jl
@@ -179,7 +179,8 @@ md"""## Clamping/clipping bincounts and errorbars
 | clamp_errors = true (default) | - | - |
 
 !!! note
-	`clamp_bincounts` only works with `stairs()` and `barplot()` directly. See Makie upstream github issue: [https://github.com/MakieOrg/Makie.jl/issues/3904](https://github.com/MakieOrg/Makie.jl/issues/3904)
+    `clamp_bincounts` only works with `stairs()` and `barplot()` directly (does not work with `stephist(), hist()` for the moment.
+    See Makie upstream github issue: [https://github.com/MakieOrg/Makie.jl/issues/3904](https://github.com/MakieOrg/Makie.jl/issues/3904)
 
 """
 
@@ -187,9 +188,9 @@ md"""## Clamping/clipping bincounts and errorbars
 let h = Hist1D(;binedges=0:2, bincounts=[-0.1, 0.1], sumw2=[0.1, 0.1])
 	fig = Figure()
 	
-	barplot(fig[1,1], h;); errorbars!(h; clamp_errors=false);
-	barplot(fig[2,1], h;); errorbars!(h; clamp_errors=true);
-	barplot(fig[2,2], h; clamp_bincounts=true); errorbars!(h; clamp_bincounts=true, clamp_errors=true);
+	scatter(fig[1,1], h;); errorbars!(h; clamp_errors=false);
+	scatter(fig[2,1], h;); errorbars!(h; clamp_errors=true);
+	scatter(fig[2,2], h; clamp_bincounts=true); errorbars!(h; clamp_bincounts=true, clamp_errors=true);
 
 	fig
 end

--- a/docs/src/notebooks/makie_plotting.jl
+++ b/docs/src/notebooks/makie_plotting.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.19.40
+# v0.19.42
 
 using Markdown
 using InteractiveUtils
@@ -13,7 +13,7 @@ let
     using Pkg: Pkg
     Pkg.activate(docs_dir)
     Pkg.develop(; path=pkg_dir)
-    Pkg.instantiate()
+    Pkg.update()
 end;
 
 # ╔═╡ 82a6fb18-e9c9-450d-9c93-e05bd6cf5859

--- a/docs/src/notebooks/makie_plotting.jl
+++ b/docs/src/notebooks/makie_plotting.jl
@@ -52,7 +52,7 @@ end
 
 # ╔═╡ 91a8b01a-54e7-4955-bb56-1803d3f2576a
 begin
-	h1_log = Hist1D(rand(10^5);binedges = [0.001, 0.01, 0.1, 1])
+	h1_log = Hist1D(rand(10^5); binedges = [0.001, 0.01, 0.1, 1])
 	ax_log = plot(h1_log; axis=(;xscale=log10, yscale=log10), label = "log-log scale")
 	xlims!(0.0001, nothing)
 	ylims!(1, nothing)
@@ -83,9 +83,9 @@ md"""
 begin
 	fig2d = Figure()
 	h2d = Hist2D((randn(10000), randn(10000)))
-	plot(fig2d[1,2], h2d)
+	_, _heatmap = plot(fig2d[1,2], h2d)
 	statbox!(fig2d, h2d; position=(1,1))
-	Colorbar(fig2d[1,3])
+	Colorbar(fig2d[1,3], _heatmap)
 	fig2d
 end
 
@@ -100,7 +100,6 @@ begin
 	f2_uneven = Figure()
 	plot(f2_uneven[2,1], h2d_even; axis=(title="even x-binning", ))
 	plot(f2_uneven[1,1], h2d_uneven; axis=(title="uneven x-binning", ))
-	Colorbar(f2_uneven[:,2])
 	f2_uneven
 end
 
@@ -171,6 +170,41 @@ begin
     f_ratio
 end
 
+# ╔═╡ 877172c9-df03-4157-af80-a99f3bd5bd3f
+md"""## Clamping/clipping bincounts and errorbars
+
+| - | clamp_bincounts = false (default) | clamp_bincounts = true |
+| --- | -------------------------------- | -------------------------------- |
+| clamp_errors = false | - | - |
+| clamp_errors = true (default) | - | - |
+
+!!! note
+	`clamp_bincounts` only works with `stairs()` and `barplot()` directly. See Makie upstream github issue: [https://github.com/MakieOrg/Makie.jl/issues/3904](https://github.com/MakieOrg/Makie.jl/issues/3904)
+
+"""
+
+# ╔═╡ b9ae652e-75bf-454b-83c6-fa6b4ef74faa
+let h = Hist1D(;binedges=0:2, bincounts=[-0.1, 0.1], sumw2=[0.1, 0.1])
+	fig = Figure()
+	
+	barplot(fig[1,1], h;); errorbars!(h; clamp_errors=false);
+	barplot(fig[2,1], h;); errorbars!(h; clamp_errors=true);
+	barplot(fig[2,2], h; clamp_bincounts=true); errorbars!(h; clamp_bincounts=true, clamp_errors=true);
+
+	fig
+end
+
+# ╔═╡ f9255f7c-fd44-46cc-bccc-a8c4b5033502
+let h = Hist1D(;binedges=0:2, bincounts=[-0.1, 0.1], sumw2=[0.1, 0.1])
+	fig = Figure()
+	
+	stairs(fig[1,1], h;); errorbars!(h; clamp_errors=false);
+	stairs(fig[2,1], h;); errorbars!(h; clamp_errors=true);
+	stairs(fig[2,2], h; clamp_bincounts=true); errorbars!(h; clamp_bincounts=true, clamp_errors=true);
+
+	fig
+end
+
 # ╔═╡ 2f97d05b-9103-451e-8fce-bb7458acf2ba
 md"""
 # Shading/Hatching errorbar band
@@ -213,6 +247,9 @@ end
 # ╠═089fb6a1-3f2a-45f4-b4bf-4013dee3a6da
 # ╠═a3dd8f72-d292-4f85-be76-2647b9433b42
 # ╠═b1188446-d16b-4e0c-93be-c5e3d0de379c
+# ╟─877172c9-df03-4157-af80-a99f3bd5bd3f
+# ╠═b9ae652e-75bf-454b-83c6-fa6b4ef74faa
+# ╠═f9255f7c-fd44-46cc-bccc-a8c4b5033502
 # ╟─2f97d05b-9103-451e-8fce-bb7458acf2ba
 # ╠═b114c8a7-5f01-44fe-9660-b5021d359399
 # ╠═fae56f0f-bac4-4dea-b33c-d45e6f3b51fc

--- a/ext/FHistMakieExt.jl
+++ b/ext/FHistMakieExt.jl
@@ -6,39 +6,6 @@ isdefined(Base, :get_extension) ? (using Makie) : (using ..Makie)
 
 import FHist: stackedhist, stackedhist!
 
-const SAFE_LOG = Ref(true)
-
-"""
-    set_safe_log(x::Bool)
-
-Turn on/off SAFE_LOG, to plot histograms without/with negative values. By default is `true`.
-"""
-function set_safe_log(x::Bool)
-    SAFE_LOG[]=x
-end
-
-"""
-    _clip_for_log(c_vec)
-
-Internal fuction to clip counts of histogram. 
-"""
-function _clip_counts!(c_vec)
-    min_positive = 2*eps()  
-    @. c_vec = max(c_vec, min_positive)
-end
-
-"""
-    _clip_errors!(e_vec,c_vec)
-
-Internal fuction to clip errors of histogram. 
-"""
-function _clip_errors!(e_vec,c_vec)
-    min_positive = eps()
-    mask =  c_vec - e_vec .< min_positive
-    e_vec[mask] = c_vec[mask] .- min_positive
-end
-
-
 """
     stackedhist(hs:AbstractVector{<:Hist1D}; errors=true|:bar|:shade, color=Makie.wong_colors())
 
@@ -145,39 +112,39 @@ function Makie.convert_arguments(P::Type{<:Stairs}, h::Hist1D)
     edges = binedges(h)
     phantomedge = edges[end] # to bring step back to baseline
     bc = bincounts(h)
-    SAFE_LOG[] && _clip_counts!(bc)
     convert_arguments(P, vcat(edges, phantomedge), vcat(eps(), bc, eps()))
 end
 
 function Makie.convert_arguments(P::Type{<:Scatter}, h::Hist1D)
     bc = bincounts(h)
-    SAFE_LOG[] && _clip_counts!(bc)
     convert_arguments(P, bincenters(h), bc)
 end  
 
 function Makie.convert_arguments(P::Type{<:BarPlot}, h::Hist1D)
     bc = bincounts(h)
-    SAFE_LOG[] && _clip_counts!(bc)
     convert_arguments(P, bincenters(h), bc)
 end
 
+function Makie.plot!(plot::Errorbars{<:Tuple{<:Hist1D}})
+    scene = Makie.parent_scene(plot)
+    attributes = Makie.default_theme(scene, Makie.Errorbars)
+    for key in keys(attributes)
+        attributes[key] = get(plot.attributes, key, attributes[key])
+    end
+    err_func = get(plot.attributes, :error_function, Ref(FHist.sqrt))
 
-function Makie.convert_arguments(P::Type{<:Makie.Errorbars}, h::FHist.Hist1D)
-    se = FHist.binerrors(FHist.sqrt, h)
-    bincounts = FHist.bincounts(h)
-    if all(==(1.0), FHist.sumw2(h))
-        # no weights used in filling
-        convert_arguments(P, FHist.bincenters(h), bincounts, se)
-    else
-        # weights used, switch to pearson error if error bar dips below zero
-        pe = FHist.binerrors(FHist.sqrt_err, h)
-        err_high, err_low = first.(pe), last.(pe)
-        if SAFE_LOG[]
-            _clip_counts!(bincounts)
-            _clip_errors!(err_low, bincounts)
+    h = plot[1]
+    xs = FHist.bincenters(h[])
+    ys = FHist.bincounts(h[])
+    errs = FHist.binerrors(err_func[], h[])
+    hi_errs, lo_errs = first.(errs), last.(errs)
+    for i in eachindex(ys, lo_errs)
+        if ys[i] - lo_errs[i] <= 0
+            lo_errs[i] = ys[i] - eps()
         end
-        convert_arguments(P, FHist.bincenters(h), bincounts, err_low, err_high)
-    end   
+    end
+    errorbars!(plot, attributes, xs, ys, lo_errs, hi_errs)
+    plot
 end
 
 function Makie.convert_arguments(P::Type{<:CrossBar}, h::Hist1D)

--- a/ext/FHistMakieExt.jl
+++ b/ext/FHistMakieExt.jl
@@ -174,14 +174,14 @@ function Makie.convert_arguments(P::Type{<:Makie.Errorbars}, h::FHist.Hist1D; cl
 
     if clamp_bincounts && clamp_errors
         _clamp_counts_errors!(ys, lo_errs, hi_errs)
-    elseif clamp_bincounts && !clamp_errors
-        _clamp_counts(ys)
     elseif !clamp_bincounts && clamp_errors
         for i in eachindex(ys, lo_errs)
             if ys[i] - lo_errs[i] <= 0
                 lo_errs[i] = ys[i] - eps()
             end
         end
+    elseif clamp_bincounts && !clamp_errors
+        error("Clamping bincounts without also clamping errors will produce incorrect visualization.")
     end
     convert_arguments(P, xs, ys, lo_errs, hi_errs)
 end

--- a/ext/FHistMakieExt.jl
+++ b/ext/FHistMakieExt.jl
@@ -112,7 +112,9 @@ function Makie.convert_arguments(P::Type{<:Stairs}, h::Hist1D)
     edges = binedges(h)
     phantomedge = edges[end] # to bring step back to baseline
     bc = bincounts(h)
-    convert_arguments(P, vcat(edges, phantomedge), vcat(eps(), bc, eps()))
+    z = zero(eltype(bc))
+    nonzero_bincounts = replace(bc, z => bot)
+    convert_arguments(P, vcat(edges, phantomedge), vcat(bot, nonzero_bincounts, bot))
 end
 
 function Makie.convert_arguments(P::Type{<:Scatter}, h::Hist1D)

--- a/ext/FHistMakieExt.jl
+++ b/ext/FHistMakieExt.jl
@@ -128,9 +128,9 @@ function Makie.convert_arguments(P::Type{<:BarPlot}, h::Hist1D)
     convert_arguments(P, bincenters(h), bc)
 end
 
-Makie.used_attributes(::Type{<: Errorbars}, h::Hist1D) = (:clamp, :error_function)
+Makie.used_attributes(::Type{<: Errorbars}, h::Hist1D) = (:clamp_errors, :error_function)
 
-function Makie.convert_arguments(P::Type{<:Makie.Errorbars}, h::FHist.Hist1D; clamp=true, error_function=nothing)
+function Makie.convert_arguments(P::Type{<:Makie.Errorbars}, h::FHist.Hist1D; clamp_errors=true, error_function=nothing)
     xs = FHist.bincenters(h)
     ys = FHist.bincounts(h)
     errs = if isnothing(error_function)
@@ -139,7 +139,7 @@ function Makie.convert_arguments(P::Type{<:Makie.Errorbars}, h::FHist.Hist1D; cl
         FHist.binerrors(error_function, h)
     end
     hi_errs, lo_errs = first.(errs), last.(errs)
-    if clamp
+    if clamp_errors
         for i in eachindex(ys, lo_errs)
             if ys[i] - lo_errs[i] <= 0
                 lo_errs[i] = ys[i] - eps()

--- a/ext/FHistMakieExt.jl
+++ b/ext/FHistMakieExt.jl
@@ -111,6 +111,7 @@ Makie.MakieCore.plottype(::Hist1D) = Hist
 function Makie.convert_arguments(P::Type{<:Stairs}, h::Hist1D)
     edges = binedges(h)
     phantomedge = edges[end] # to bring step back to baseline
+    bot = eps()
     bc = bincounts(h)
     z = zero(eltype(bc))
     nonzero_bincounts = replace(bc, z => bot)


### PR DESCRIPTION
This is an alternative to #116 @sfranchel 

~~I'm a bit hesitant to clip the error bars to positive~~

## ~~DO NOT MERGE~~

~~Blocked by https://github.com/MakieOrg/Makie.jl/issues/3901~~

~~The following works on older Makie but not the latest one, I think it's a bug~~

```julia
julia> h = Hist1D(;binedges=0:1, bincounts=[0.1], sumw2=[0.1])
edges: [0.0, 1.0]
bin counts: [0.1]
total count: 0.1

julia> stephist(h); errorbars!(h); current_figure()
```
![image](https://github.com/Moelf/FHist.jl/assets/5306213/85ce27e1-56aa-443c-b99a-7e4a141865f9)



```julia
julia> stephist(h); errorbars!(h; error_function=FHist.pearson_err); current_figure()
```


![image](https://github.com/Moelf/FHist.jl/assets/5306213/6723550d-7100-458f-9a09-ff38ff036921)

