### PR TITLE
overload `Base.clamp()`/`Base.clamp!()` for clipping histogram bincounts

### DIFF
--- a/src/FHist.jl
+++ b/src/FHist.jl
@@ -158,7 +158,11 @@ for (H, N) in ((:Hist1D, 1), (:Hist2D, 2), (:Hist3D, 3))
         @doc """
                 clamp(hist::H, lo_limit, hi_limit) --> new_hist::H
                 FHist.clamp!(hist, lo_limit, hi_limit) --> hist
-            Clamp the `bincounts()` of a histogram and return a copy of the histogram. `FHist.clamp!()` is the in-place variation.
+
+            Clamp (or called clip) the `bincounts()` of a histogram and return a copy of the histogram. `FHist.clamp!()` is the in-place variation.
+
+            !!! note
+                By construction, the `integral()` of the histogram will also change. Clamping does not change `sumw2` values.
         """
         function Base.clamp(h::$H, lo_limit, hi_limit)
             newh = deepcopy(h)

--- a/src/FHist.jl
+++ b/src/FHist.jl
@@ -168,7 +168,7 @@ for (H, N) in ((:Hist1D, 1), (:Hist2D, 2), (:Hist3D, 3))
             newh = deepcopy(h)
             return clamp!(newh, lo_limit, hi_limit)
         end
-        function clamp!(h::$H, lo_limit, hi_limit)
+        function Base.clamp!(h::$H, lo_limit, hi_limit)
             bc = bincounts(h) 
             @. bc = clamp(bc, lo_limit, hi_limit)
             return h

--- a/src/FHist.jl
+++ b/src/FHist.jl
@@ -155,6 +155,21 @@ for (H, N) in ((:Hist1D, 1), (:Hist2D, 2), (:Hist3D, 3))
         binerrors(f::T, h::$H) where T<:Function = f.(sumw2(h))
         binerrors(h::$H) = binerrors(sqrt, h)
 
+        @doc """
+                clamp(hist::H, lo_limit, hi_limit) --> new_hist::H
+                FHist.clamp!(hist, lo_limit, hi_limit) --> hist
+            Clamp the `bincounts()` of a histogram and return a copy of the histogram. `FHist.clamp!()` is the in-place variation.
+        """
+        function Base.clamp(h::$H, lo_limit, hi_limit)
+            newh = deepcopy(h)
+            return clamp!(newh, lo_limit, hi_limit)
+        end
+        function clamp!(h::$H, lo_limit, hi_limit)
+            bc = bincounts(h) 
+            @. bc = clamp(bc, lo_limit, hi_limit)
+            return h
+        end
+
         function Base.:(==)(h1::$H, h2::$H)
             bincounts(h1) == bincounts(h2) &&
                 binedges(h1) == binedges(h2) &&

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -617,14 +617,14 @@ end
     h = Hist1D(;binedges=0:2, bincounts=bc_1D, sumw2=[0.1, 0.2])
     h2 = Hist1D(;binedges=0:2, bincounts=clamp.(bc_1D, eps(), Inf), sumw2=[0.1, 0.2])
     @test clamp(h, eps(), Inf) == h2
-    @test h2 == FHist.clamp!(deepcopy(h), eps(), Inf)
+    @test h2 == clamp!(deepcopy(h), eps(), Inf)
 
     bc_2D = [-0.1  1.0;
             -0.2  3.0]
     h2d = Hist2D(;binedges=(0:2, 0:2), bincounts=bc_2D)
     h2d2 = Hist2D(;binedges=(0:2, 0:2), bincounts=clamp.(bc_2D, eps(), Inf))
     @test clamp(h2d, eps(), Inf) == h2d2
-    @test h2d2 == FHist.clamp!(deepcopy(h2d), eps(), Inf)
+    @test h2d2 == clamp!(deepcopy(h2d), eps(), Inf)
 end
 
 include("hdf5.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -612,4 +612,19 @@ end
     @test all(significance(h1,h2) .≈ (9.839916447569484, 0.30998654607114046))
 end
 
+@testset "Clamping histogram bincounts" begin
+    bc_1D = [-0.1, 1.0]
+    h = Hist1D(;binedges=0:2, bincounts=bc_1D, sumw2=[0.1, 0.2])
+    h2 = Hist1D(;binedges=0:2, bincounts=clamp.(bc_1D, eps(), Inf), sumw2=[0.1, 0.2])
+    @test clamp(h, eps(), Inf) == h2
+    @test h2 == FHist.clamp!(deepcopy(h), eps(), Inf)
+
+    bc_2D = [-0.1  1.0;
+            -0.2  3.0]
+    h2d = Hist2D(;binedges=(0:2, 0:2), bincounts=bc_2D)
+    h2d2 = Hist2D(;binedges=(0:2, 0:2), bincounts=clamp.(bc_2D, eps(), Inf))
+    @test clamp(h2d, eps(), Inf) == h2d2
+    @test h2d2 == FHist.clamp!(deepcopy(h2d), eps(), Inf)
+end
+
 include("hdf5.jl")


### PR DESCRIPTION
Is `Base.clamp` a good name for this? or it's too ambiguous?