### PR TITLE
add static compilation example

### DIFF
--- a/C_FHist/C_FHist.jl
+++ b/C_FHist/C_FHist.jl
@@ -1,0 +1,14 @@
+module C_FHist
+
+using FHist: Hist1D, _fast_bincounts_1d!
+
+Base.@ccallable function hist1d(input::Ptr{Cdouble}, Ninput::Clong, bincounts::Ptr{Cdouble}, Nbincounts::Clong, start::Cdouble, step::Cdouble, stop::Cdouble)::Cint
+    np_input = unsafe_wrap(Array{Float64}, input, Ninput, own=false)
+    np_bincounts = unsafe_wrap(Array{Float64}, bincounts, Nbincounts, own=false)
+    binedges = start:step:stop
+    h = Hist1D(; bincounts=np_bincounts, binedges)
+    _fast_bincounts_1d!(h, np_input, binedges)
+    return 0
+end
+
+end

--- a/C_FHist/C_FHist.jl
+++ b/C_FHist/C_FHist.jl
@@ -2,13 +2,13 @@ module C_FHist
 
 using FHist: Hist1D, _fast_bincounts_1d!
 
-Base.@ccallable function hist1d(input::Ptr{Cdouble}, Ninput::Clong, bincounts::Ptr{Cdouble}, Nbincounts::Clong, start::Cdouble, step::Cdouble, stop::Cdouble)::Cint
+Base.@ccallable function hist1d(input::Ptr{Cdouble}, Ninput::Clong, bincounts::Ptr{Cdouble}, Nbincounts::Clong, start::Cdouble, step::Cdouble, stop::Cdouble)::Cvoid
     np_input = unsafe_wrap(Array{Float64}, input, Ninput, own=false)
     np_bincounts = unsafe_wrap(Array{Float64}, bincounts, Nbincounts, own=false)
     binedges = start:step:stop
     h = Hist1D(; bincounts=np_bincounts, binedges)
     _fast_bincounts_1d!(h, np_input, binedges)
-    return 0
+    return nothing
 end
 
 end

--- a/C_FHist/README.md
+++ b/C_FHist/README.md
@@ -8,7 +8,7 @@ juliaup add 1.12
 ## How to test
 
 ```bash
->julia +1.12 --startup-file=no --project=.. -e "using Pkg; Pkg.update()"
+>julia +1.12 --project=.. -e "using Pkg; Pkg.update()"
 # the the -beta4+0 is the latest version at the time of writing, change it to the latest version
 # the x64.linux.gnu need to be changed to your platform
 >julia +1.12 --project=.. ~/.julia/juliaup/julia-1.12.0-beta4+0.x64.linux.gnu/share/julia/juliac.jl --output-lib libfhistjl.so --compile-ccallable --experimental --trim C_FHist.jl
@@ -38,23 +38,23 @@ Platform Info:
 =====================================
 Input size: 1000
 All close: True
-Numpy    time (μs): 0.021641701459884644
-FHist.jl time (μs): 0.003958120942115784
+Numpy    time (ms): 0.021641701459884644
+FHist.jl time (ms): 0.003958120942115784
 =====================================
 Input size: 10000
 All close: True
-Numpy    time (μs): 0.05824156105518341
-FHist.jl time (μs): 0.011725164949893951
+Numpy    time (ms): 0.05824156105518341
+FHist.jl time (ms): 0.011725164949893951
 =====================================
 Input size: 100000
 All close: True
-Numpy    time (μs): 0.438716821372509
-FHist.jl time (μs): 0.0859750434756279
+Numpy    time (ms): 0.438716821372509
+FHist.jl time (ms): 0.0859750434756279
 =====================================
 Input size: 1000000
 All close: True
-Numpy    time (μs): 3.94724179059267
-FHist.jl time (μs): 0.829133577644825
+Numpy    time (ms): 3.94724179059267
+FHist.jl time (ms): 0.829133577644825
 ```
 
 ## Results on Linux x86_64 (Ryzen 9 3900X)
@@ -76,21 +76,21 @@ Platform Info:
 =====================================
 Input size: 1000
 All close: True
-Numpy    time (μs): 0.05090880440548062
-FHist.jl time (μs): 0.007097609341144562
+Numpy    time (ms): 0.05090880440548062
+FHist.jl time (ms): 0.007097609341144562
 =====================================
 Input size: 10000
 All close: True
-Numpy    time (μs): 0.19860140746459365
-FHist.jl time (μs): 0.020549201872199774
+Numpy    time (ms): 0.19860140746459365
+FHist.jl time (ms): 0.020549201872199774
 =====================================
 Input size: 100000
 All close: True
-Numpy    time (μs): 1.3177349930629134
-FHist.jl time (μs): 0.19442759221419692
+Numpy    time (ms): 1.3177349930629134
+FHist.jl time (ms): 0.19442759221419692
 =====================================
 Input size: 1000000
 All close: True
-Numpy    time (μs): 6.48591200588271
-FHist.jl time (μs): 1.8390380078926682
+Numpy    time (ms): 6.48591200588271
+FHist.jl time (ms): 1.8390380078926682
 ```

--- a/C_FHist/README.md
+++ b/C_FHist/README.md
@@ -11,24 +11,41 @@ juliaup add nightly
 julia +nightly --project=.. ~/.julia/juliaup/julia-nightly/share/julia/juliac/juliac.jl --output-lib libfhistjl.so --compile-ccallable --experimental --trim C_FHist.jl
 
 > pixi run python test.py
+```
+
+
+## Results on macOS M4
+
+```
+> julia +nightly -e "using InteractiveUtils; versioninfo()"
+Julia Version 1.13.0-DEV.817
+Commit c0cc1e1022b (2025-07-04 12:09 UTC)
+Build Info:
+  Official https://julialang.org release
+Platform Info:
+  OS: macOS (arm64-apple-darwin24.0.0)
+  CPU: 10 × Apple M4
+  LLVM: libLLVM-20.1.2 (ORCJIT, apple-m4)
+
+> pixi run python test.py
 =====================================
 Input size: 1000
 All close: True
-Numpy    time (μs): 0.04149973392486572
-FHist.jl time (μs): 0.007666647434234619
+Numpy    time (μs): 0.02420824021100998
+FHist.jl time (μs): 0.004041567444801331
 =====================================
 Input size: 10000
 All close: True
-Numpy    time (μs): 0.10570790618658066
-FHist.jl time (μs): 0.02658367156982422
+Numpy    time (μs): 0.06623342633247375
+FHist.jl time (μs): 0.011583417654037476
 =====================================
 Input size: 100000
 All close: True
-Numpy    time (μs): 0.8217496797442436
-FHist.jl time (μs): 0.4670834168791771
+Numpy    time (μs): 0.5286000669002533
+FHist.jl time (μs): 0.09375009685754776
 =====================================
 Input size: 1000000
 All close: True
-Numpy    time (μs): 10.170875117182732
-FHist.jl time (μs): 7.914000190794468
+Numpy    time (μs): 4.397133179008961
+FHist.jl time (μs): 0.8317416533827782
 ```

--- a/C_FHist/README.md
+++ b/C_FHist/README.md
@@ -35,23 +35,23 @@ Platform Info:
 =====================================
 Input size: 1000
 All close: True
-Numpy    time (μs): 0.02420824021100998
-FHist.jl time (μs): 0.004041567444801331
+Numpy    time (μs): 0.01876652240753174
+FHist.jl time (μs): 0.0034248456358909607
 =====================================
 Input size: 10000
 All close: True
-Numpy    time (μs): 0.06623342633247375
-FHist.jl time (μs): 0.011583417654037476
+Numpy    time (μs): 0.05549192428588867
+FHist.jl time (μs): 0.010091438889503479
 =====================================
 Input size: 100000
 All close: True
-Numpy    time (μs): 0.5286000669002533
-FHist.jl time (μs): 0.09375009685754776
+Numpy    time (μs): 0.4449000582098961
+FHist.jl time (μs): 0.08234996348619461
 =====================================
 Input size: 1000000
 All close: True
-Numpy    time (μs): 4.397133179008961
-FHist.jl time (μs): 0.8317416533827782
+Numpy    time (μs): 3.905266709625721
+FHist.jl time (μs): 0.7887914776802063
 ```
 
 

--- a/C_FHist/README.md
+++ b/C_FHist/README.md
@@ -10,8 +10,25 @@ juliaup add nightly
 ```bash
 julia +nightly --project=.. ~/.julia/juliaup/julia-nightly/share/julia/juliac/juliac.jl --output-lib libfhistjl.so --compile-ccallable --experimental --trim C_FHist.jl
 
-# these are numpy.histogram time and julia time respectively
-python test.py
-5.117958411574364e-05
-3.2396082766354086e-05
+> pixi run python test.py
+=====================================
+Input size: 1000
+All close: True
+Numpy    time (μs): 0.04149973392486572
+FHist.jl time (μs): 0.007666647434234619
+=====================================
+Input size: 10000
+All close: True
+Numpy    time (μs): 0.10570790618658066
+FHist.jl time (μs): 0.02658367156982422
+=====================================
+Input size: 100000
+All close: True
+Numpy    time (μs): 0.8217496797442436
+FHist.jl time (μs): 0.4670834168791771
+=====================================
+Input size: 1000000
+All close: True
+Numpy    time (μs): 10.170875117182732
+FHist.jl time (μs): 7.914000190794468
 ```

--- a/C_FHist/README.md
+++ b/C_FHist/README.md
@@ -1,0 +1,17 @@
+## Setup Julia nightly:
+Follow instruction at https://julialang.org/install/
+```
+curl -fsSL https://install.julialang.org | sh
+juliaup add nightly
+```
+
+## How to test
+
+```bash
+julia +nightly --project=.. ~/.julia/juliaup/julia-nightly/share/julia/juliac/juliac.jl --output-lib libfhistjl.so --compile-ccallable --experimental --trim C_FHist.jl
+
+# these are numpy.histogram time and julia time respectively
+python test.py
+5.117958411574364e-05
+3.2396082766354086e-05
+```

--- a/C_FHist/README.md
+++ b/C_FHist/README.md
@@ -2,13 +2,16 @@
 Follow instruction at https://julialang.org/install/
 ```
 curl -fsSL https://install.julialang.org | sh
-juliaup add nightly
+juliaup add 1.12
 ```
 
 ## How to test
 
 ```bash
->julia +nightly --project=.. ~/.julia/juliaup/julia-nightly/share/julia/juliac/juliac.jl --output-lib libfhistjl.so --compile-ccallable --experimental --trim C_FHist.jl
+>julia +1.12 --startup-file=no --project=.. -e "using Pkg; Pkg.update()"
+# the the -beta4+0 is the latest version at the time of writing, change it to the latest version
+# the x64.linux.gnu need to be changed to your platform
+>julia +1.12 --project=.. ~/.julia/juliaup/julia-1.12.0-beta4+0.x64.linux.gnu/share/julia/juliac.jl --output-lib libfhistjl.so --compile-ccallable --experimental --trim C_FHist.jl
 
 >pixi ls -x
 Package  Version  Build            Size     Kind   Source
@@ -17,78 +20,77 @@ numpy    2.3.1    py313h41a2e72_0  6.3 MiB  conda  numpy
 > pixi run python test.py
 ```
 
-
 ## Results on macOS ARM (Mac Mini M4)
-
 ```
-> julia +nightly -e "using InteractiveUtils; versioninfo()"
-Julia Version 1.13.0-DEV.817
-Commit c0cc1e1022b (2025-07-04 12:09 UTC)
+> julia +1.12 -e "using InteractiveUtils; versioninfo()"
+Julia Version 1.12.0-beta4
+Commit 600ac61d3d2 (2025-06-05 07:03 UTC)
 Build Info:
   Official https://julialang.org release
 Platform Info:
   OS: macOS (arm64-apple-darwin24.0.0)
   CPU: 10 × Apple M4
-  LLVM: libLLVM-20.1.2 (ORCJIT, apple-m4)
-
-> pixi run python test.py
-=====================================
-Input size: 1000
-All close: True
-Numpy    time (μs): 0.01876652240753174
-FHist.jl time (μs): 0.0034248456358909607
-=====================================
-Input size: 10000
-All close: True
-Numpy    time (μs): 0.05549192428588867
-FHist.jl time (μs): 0.010091438889503479
-=====================================
-Input size: 100000
-All close: True
-Numpy    time (μs): 0.4449000582098961
-FHist.jl time (μs): 0.08234996348619461
-=====================================
-Input size: 1000000
-All close: True
-Numpy    time (μs): 3.905266709625721
-FHist.jl time (μs): 0.7887914776802063
-```
-
-
-## Results on Linux x86_64 (Ryzen 9 3900X)
-
-```
-> julia +nightly -e "using InteractiveUtils; versioninfo()"
-Julia Version 1.13.0-DEV.819
-Commit 4846c3d938b (2025-07-04 15:43 UTC)
-Build Info:
-  Official https://julialang.org release
-Platform Info:
-  OS: Linux (x86_64-linux-gnu)
-  CPU: 24 × AMD Ryzen 9 3900X 12-Core Processor
   WORD_SIZE: 64
-  LLVM: libLLVM-20.1.2 (ORCJIT, znver2)
+  LLVM: libLLVM-18.1.7 (ORCJIT, apple-m1)
   GC: Built with stock GC
 
 > pixi run python test.py
 =====================================
 Input size: 1000
 All close: True
-Numpy    time (μs): 0.050083198584616184
-FHist.jl time (μs): 0.006594602018594742
+Numpy    time (μs): 0.021641701459884644
+FHist.jl time (μs): 0.003958120942115784
 =====================================
 Input size: 10000
 All close: True
-Numpy    time (μs): 0.1986411982215941
-FHist.jl time (μs): 0.01715040416456759
+Numpy    time (μs): 0.05824156105518341
+FHist.jl time (μs): 0.011725164949893951
 =====================================
 Input size: 100000
 All close: True
-Numpy    time (μs): 1.3279114034958184
-FHist.jl time (μs): 0.12177939643152058
+Numpy    time (μs): 0.438716821372509
+FHist.jl time (μs): 0.0859750434756279
 =====================================
 Input size: 1000000
 All close: True
-Numpy    time (μs): 6.595311197452247
-FHist.jl time (μs): 1.4640979992691427
+Numpy    time (μs): 3.94724179059267
+FHist.jl time (μs): 0.829133577644825
+```
+
+## Results on Linux x86_64 (Ryzen 9 3900X)
+
+```
+> julia +1.12 -e "using InteractiveUtils; versioninfo()"
+Julia Version 1.12.0-beta4
+Commit 600ac61d3d2 (2025-06-05 07:03 UTC)
+Build Info:
+  Official https://julialang.org release
+Platform Info:
+  OS: Linux (x86_64-linux-gnu)
+  CPU: 24 × AMD Ryzen 9 3900X 12-Core Processor
+  WORD_SIZE: 64
+  LLVM: libLLVM-18.1.7 (ORCJIT, znver2)
+  GC: Built with stock GC
+
+> pixi run python test.py
+=====================================
+Input size: 1000
+All close: True
+Numpy    time (μs): 0.05090880440548062
+FHist.jl time (μs): 0.007097609341144562
+=====================================
+Input size: 10000
+All close: True
+Numpy    time (μs): 0.19860140746459365
+FHist.jl time (μs): 0.020549201872199774
+=====================================
+Input size: 100000
+All close: True
+Numpy    time (μs): 1.3177349930629134
+FHist.jl time (μs): 0.19442759221419692
+=====================================
+Input size: 1000000
+All close: True
+Numpy    time (μs): 6.48591200588271
+FHist.jl time (μs): 1.8390380078926682
 ```

--- a/C_FHist/README.md
+++ b/C_FHist/README.md
@@ -8,13 +8,17 @@ juliaup add nightly
 ## How to test
 
 ```bash
-julia +nightly --project=.. ~/.julia/juliaup/julia-nightly/share/julia/juliac/juliac.jl --output-lib libfhistjl.so --compile-ccallable --experimental --trim C_FHist.jl
+>julia +nightly --project=.. ~/.julia/juliaup/julia-nightly/share/julia/juliac/juliac.jl --output-lib libfhistjl.so --compile-ccallable --experimental --trim C_FHist.jl
+
+>pixi ls -x
+Package  Version  Build            Size     Kind   Source
+numpy    2.3.1    py313h41a2e72_0  6.3 MiB  conda  numpy
 
 > pixi run python test.py
 ```
 
 
-## Results on macOS M4
+## Results on macOS ARM (Mac Mini M4)
 
 ```
 > julia +nightly -e "using InteractiveUtils; versioninfo()"
@@ -51,7 +55,7 @@ FHist.jl time (μs): 0.8317416533827782
 ```
 
 
-## Results on Linux x86_64
+## Results on Linux x86_64 (Ryzen 9 3900X)
 
 ```
 > julia +nightly -e "using InteractiveUtils; versioninfo()"

--- a/C_FHist/README.md
+++ b/C_FHist/README.md
@@ -74,21 +74,21 @@ Platform Info:
 =====================================
 Input size: 1000
 All close: True
-Numpy    time (μs): 0.04856220039073378
-FHist.jl time (μs): 0.00662259990349412
+Numpy    time (μs): 0.050083198584616184
+FHist.jl time (μs): 0.006594602018594742
 =====================================
 Input size: 10000
 All close: True
-Numpy    time (μs): 0.2016977989114821
-FHist.jl time (μs): 0.04962040111422539
+Numpy    time (μs): 0.1986411982215941
+FHist.jl time (μs): 0.01715040416456759
 =====================================
 Input size: 100000
 All close: True
-Numpy    time (μs): 1.333067798987031
-FHist.jl time (μs): 0.12432239891495554
+Numpy    time (μs): 1.3279114034958184
+FHist.jl time (μs): 0.12177939643152058
 =====================================
 Input size: 1000000
 All close: True
-Numpy    time (μs): 6.55430739861913
-FHist.jl time (μs): 1.6349460027413443
+Numpy    time (μs): 6.595311197452247
+FHist.jl time (μs): 1.4640979992691427
 ```

--- a/C_FHist/README.md
+++ b/C_FHist/README.md
@@ -49,3 +49,42 @@ All close: True
 Numpy    time (μs): 4.397133179008961
 FHist.jl time (μs): 0.8317416533827782
 ```
+
+
+## Results on Linux x86_64
+
+```
+> julia +nightly -e "using InteractiveUtils; versioninfo()"
+Julia Version 1.13.0-DEV.819
+Commit 4846c3d938b (2025-07-04 15:43 UTC)
+Build Info:
+  Official https://julialang.org release
+Platform Info:
+  OS: Linux (x86_64-linux-gnu)
+  CPU: 24 × AMD Ryzen 9 3900X 12-Core Processor
+  WORD_SIZE: 64
+  LLVM: libLLVM-20.1.2 (ORCJIT, znver2)
+  GC: Built with stock GC
+
+> pixi run python test.py
+=====================================
+Input size: 1000
+All close: True
+Numpy    time (μs): 0.04856220039073378
+FHist.jl time (μs): 0.00662259990349412
+=====================================
+Input size: 10000
+All close: True
+Numpy    time (μs): 0.2016977989114821
+FHist.jl time (μs): 0.04962040111422539
+=====================================
+Input size: 100000
+All close: True
+Numpy    time (μs): 1.333067798987031
+FHist.jl time (μs): 0.12432239891495554
+=====================================
+Input size: 1000000
+All close: True
+Numpy    time (μs): 6.55430739861913
+FHist.jl time (μs): 1.6349460027413443
+```

--- a/C_FHist/benchmarks.md
+++ b/C_FHist/benchmarks.md
@@ -1,0 +1,33 @@
+## On a AMD Zen2 system:
+
+### JULIA_CPU_TARGET='znver2;generic' julia +1.12
+```
+Input size: 1000000
+All close: True
+Numpy    time (μs): 6.558584200683981
+FHist.jl time (μs): 1.7967560008401051
+```
+
+### JULIA_CPU_TARGET='generic;znver2' julia +1.12
+```
+Input size: 1000000
+All close: True
+Numpy    time (μs): 6.538515799911693
+FHist.jl time (μs): 2.6081674004672095
+```
+
+### JULIA_CPU_TARGET='znver2;generic' julia +nightly
+```
+Input size: 1000000
+All close: True
+Numpy    time (μs): 6.641940600820817
+FHist.jl time (μs): 1.5721895993920043
+```
+
+### JULIA_CPU_TARGET='generic;znver2' julia +nightly
+```
+Input size: 1000000
+All close: True
+Numpy    time (μs): 6.617425798322074
+FHist.jl time (μs): 2.40858779870905
+```

--- a/C_FHist/jlsum.jl
+++ b/C_FHist/jlsum.jl
@@ -1,0 +1,4 @@
+Base.@ccallable function jlsum(p::Ptr{Cdouble}, N::Clong)::Cdouble
+    np_input = unsafe_wrap(Array{Float64}, p, N, own=false)
+    return sum(np_input)
+end

--- a/C_FHist/jlsum.py
+++ b/C_FHist/jlsum.py
@@ -22,5 +22,5 @@ for N_input in [10**4, 10**5, 10**6]:
     print("np.isclose:", np.isclose(np.sum(input_data), jlsum(input_data)))
     np_timer = timeit.Timer(lambda: np.sum(input_data))
     jl_timer = timeit.Timer(lambda: jlsum(input_data))
-    print(f"Numpy    time (μs): {np.min(np_timer.repeat(number=5, repeat=500)) / 5 * 1000}")
-    print(f"FHist.jl time (μs): {np.min(jl_timer.repeat(number=5, repeat=500)) / 5 * 1000}")
+    print(f"Numpy    time (ms): {np.min(np_timer.repeat(number=5, repeat=500)) / 5 * 1000}")
+    print(f"FHist.jl time (ms): {np.min(jl_timer.repeat(number=5, repeat=500)) / 5 * 1000}")

--- a/C_FHist/jlsum.py
+++ b/C_FHist/jlsum.py
@@ -1,0 +1,26 @@
+import ctypes
+
+lib = ctypes.CDLL('./libjlsum.so')
+lib.jlsum.argtypes = [
+        ctypes.POINTER(ctypes.c_double), ctypes.c_long,
+        ]
+lib.jlsum.restype = ctypes.c_double
+def jlsum(a):
+    res = lib.jlsum(
+            a.ctypes.data_as(ctypes.POINTER(ctypes.c_double)), 
+            ctypes.c_long(len(a)), 
+            )
+    return res
+
+
+import numpy as np
+import timeit
+for N_input in [10**4, 10**5, 10**6]:
+    input_data = np.random.rand(N_input)
+    print("=====================================")
+    print(f"Input size: {N_input}")
+    print("np.isclose:", np.isclose(np.sum(input_data), jlsum(input_data)))
+    np_timer = timeit.Timer(lambda: np.sum(input_data))
+    jl_timer = timeit.Timer(lambda: jlsum(input_data))
+    print(f"Numpy    time (μs): {np.min(np_timer.repeat(number=5, repeat=500)) / 5 * 1000}")
+    print(f"FHist.jl time (μs): {np.min(jl_timer.repeat(number=5, repeat=500)) / 5 * 1000}")

--- a/C_FHist/pixi.toml
+++ b/C_FHist/pixi.toml
@@ -1,0 +1,12 @@
+[project]
+authors = ["Jerry Ling <proton@jling.dev>"]
+channels = ["conda-forge"]
+description = "Add a short description here"
+name = "C_FHist"
+platforms = ["osx-arm64"]
+version = "0.1.0"
+
+[tasks]
+
+[dependencies]
+numpy = ">=2.3.1,<3"

--- a/C_FHist/pixi.toml
+++ b/C_FHist/pixi.toml
@@ -3,10 +3,11 @@ authors = ["Jerry Ling <proton@jling.dev>"]
 channels = ["conda-forge"]
 description = "Add a short description here"
 name = "C_FHist"
-platforms = ["osx-arm64"]
+platforms = ["linux-64", "osx-arm64"]
 version = "0.1.0"
 
 [tasks]
 
 [dependencies]
 numpy = ">=2.3.1,<3"
+ipython = ">=9.4.0,<10"

--- a/C_FHist/test.py
+++ b/C_FHist/test.py
@@ -28,12 +28,14 @@ def jlhist(a, bins, range):
 
 
 for N_input in [10**3, 10**4, 10**5, 10**6]:
-    input_data = np.random.randn(N_input)
+    input_data = np.random.rand(N_input)
+    bins = 20
     print("=====================================")
     print(f"Input size: {N_input}")
-    print("All close:", np.allclose(np.histogram(input_data, bins=10, range=(0.0, 1.0))[0], jlhist(input_data, bins=10, range=(0.0,
+    print("All close:", np.allclose(np.histogram(input_data, bins=bins, range=(0.0, 1.0))[0], jlhist(input_data,
+                                                                                                     bins=bins, range=(0.0,
                                                                                                                  1.0))))
-    np_timer = timeit.Timer(lambda: np.histogram(input_data, bins=10, range=(0.0, 1.0)))
-    jl_timer = timeit.Timer(lambda: jlhist(input_data, bins=10, range=(0.0, 1.0)))
-    print(f"Numpy    time (μs): {np.min(np_timer.repeat(number=2, repeat=500)) * 1000}")
-    print(f"FHist.jl time (μs): {np.min(jl_timer.repeat(number=2, repeat=500)) * 1000}")
+    np_timer = timeit.Timer(lambda: np.histogram(input_data, bins=bins, range=(0.0, 1.0)))
+    jl_timer = timeit.Timer(lambda: jlhist(input_data, bins=bins, range=(0.0, 1.0)))
+    print(f"Numpy    time (μs): {np.min(np_timer.repeat(number=5, repeat=200)) / 5 * 1000}")
+    print(f"FHist.jl time (μs): {np.min(jl_timer.repeat(number=5, repeat=200)) / 5 * 1000}")

--- a/C_FHist/test.py
+++ b/C_FHist/test.py
@@ -1,6 +1,7 @@
 import ctypes
 import numpy as np
 import timeit
+import time
 
 lib = ctypes.CDLL('./libfhistjl.so')
 lib.hist1d.argtypes = [
@@ -36,5 +37,5 @@ for N_input in [10**3, 10**4, 10**5, 10**6]:
                                                                                                                        1.0))))
     np_timer = timeit.Timer(lambda: np.histogram(input_data, bins=bins, range=(0.0, 1.0)))
     jl_timer = timeit.Timer(lambda: jlhist(input_data, bins=bins, range=(0.0, 1.0)))
-    print(f"Numpy    time (μs): {np.min(np_timer.repeat(number=5, repeat=200)) / 5 * 1000}")
-    print(f"FHist.jl time (μs): {np.min(jl_timer.repeat(number=5, repeat=200)) / 5 * 1000}")
+    print(f"Numpy    time (ms): {np.min(np_timer.repeat(number=5, repeat=200)) / 5 * 1000}")
+    print(f"FHist.jl time (ms): {np.min(jl_timer.repeat(number=5, repeat=200)) / 5 * 1000}")

--- a/C_FHist/test.py
+++ b/C_FHist/test.py
@@ -1,0 +1,36 @@
+import ctypes
+import numpy as np
+import timeit
+
+lib = ctypes.CDLL('./libfhistjl.so')
+
+lib.hist1d.argtypes = [
+        ctypes.POINTER(ctypes.c_double), ctypes.c_long, # input and length
+        ctypes.POINTER(ctypes.c_double), ctypes.c_long, # bincoutns and length
+        ctypes.c_double, ctypes.c_double, ctypes.c_double # binedges
+        ]
+lib.hist1d.restype = ctypes.c_int
+
+def jlhist(a, bins, range):
+    bincounts = np.zeros(bins)
+    step = (range[1] - range[0]) / bins
+
+    res = lib.hist1d(
+            input_data.ctypes.data_as(ctypes.POINTER(ctypes.c_double)), 
+            ctypes.c_long(len(input_data)), 
+            bincounts.ctypes.data_as(ctypes.POINTER(ctypes.c_double)), 
+            ctypes.c_long(len(bincounts)), 
+            ctypes.c_double(range[0]), 
+            ctypes.c_double(step),
+            ctypes.c_double(range[1])
+            )
+    return bincounts
+
+
+input_data = np.random.randn(10**4)
+
+np_timer = timeit.Timer(lambda: np.histogram(input_data, bins=10, range=(0.0, 1.0)))
+print(np_timer.timeit(1000)/1000)
+
+jl_timer = timeit.Timer(lambda: jlhist(input_data, bins=10, range=(0.0, 1.0)))
+print(jl_timer.timeit(1000)/1000)

--- a/C_FHist/test.py
+++ b/C_FHist/test.py
@@ -3,21 +3,20 @@ import numpy as np
 import timeit
 
 lib = ctypes.CDLL('./libfhistjl.so')
-
 lib.hist1d.argtypes = [
         ctypes.POINTER(ctypes.c_double), ctypes.c_long, # input and length
         ctypes.POINTER(ctypes.c_double), ctypes.c_long, # bincoutns and length
         ctypes.c_double, ctypes.c_double, ctypes.c_double # binedges
         ]
-lib.hist1d.restype = ctypes.c_int
+lib.hist1d.restype = ctypes.c_voidp
 
 def jlhist(a, bins, range):
     bincounts = np.zeros(bins)
     step = (range[1] - range[0]) / bins
 
-    res = lib.hist1d(
-            input_data.ctypes.data_as(ctypes.POINTER(ctypes.c_double)), 
-            ctypes.c_long(len(input_data)), 
+    lib.hist1d(
+            a.ctypes.data_as(ctypes.POINTER(ctypes.c_double)), 
+            ctypes.c_long(len(a)), 
             bincounts.ctypes.data_as(ctypes.POINTER(ctypes.c_double)), 
             ctypes.c_long(len(bincounts)), 
             ctypes.c_double(range[0]), 
@@ -34,7 +33,7 @@ for N_input in [10**3, 10**4, 10**5, 10**6]:
     print(f"Input size: {N_input}")
     print("All close:", np.allclose(np.histogram(input_data, bins=bins, range=(0.0, 1.0))[0], jlhist(input_data,
                                                                                                      bins=bins, range=(0.0,
-                                                                                                                 1.0))))
+                                                                                                                       1.0))))
     np_timer = timeit.Timer(lambda: np.histogram(input_data, bins=bins, range=(0.0, 1.0)))
     jl_timer = timeit.Timer(lambda: jlhist(input_data, bins=bins, range=(0.0, 1.0)))
     print(f"Numpy    time (μs): {np.min(np_timer.repeat(number=5, repeat=200)) / 5 * 1000}")

--- a/C_FHist/test.py
+++ b/C_FHist/test.py
@@ -27,10 +27,13 @@ def jlhist(a, bins, range):
     return bincounts
 
 
-input_data = np.random.randn(10**4)
-
-np_timer = timeit.Timer(lambda: np.histogram(input_data, bins=10, range=(0.0, 1.0)))
-print(np_timer.timeit(1000)/1000)
-
-jl_timer = timeit.Timer(lambda: jlhist(input_data, bins=10, range=(0.0, 1.0)))
-print(jl_timer.timeit(1000)/1000)
+for N_input in [10**3, 10**4, 10**5, 10**6]:
+    input_data = np.random.randn(N_input)
+    print("=====================================")
+    print(f"Input size: {N_input}")
+    print("All close:", np.allclose(np.histogram(input_data, bins=10, range=(0.0, 1.0))[0], jlhist(input_data, bins=10, range=(0.0,
+                                                                                                                 1.0))))
+    np_timer = timeit.Timer(lambda: np.histogram(input_data, bins=10, range=(0.0, 1.0)))
+    jl_timer = timeit.Timer(lambda: jlhist(input_data, bins=10, range=(0.0, 1.0)))
+    print(f"Numpy    time (μs): {np.min(np_timer.repeat(number=2, repeat=500)) * 1000}")
+    print(f"FHist.jl time (μs): {np.min(jl_timer.repeat(number=2, repeat=500)) * 1000}")

--- a/src/hist1d.jl
+++ b/src/hist1d.jl
@@ -1,8 +1,8 @@
-function _fast_bincounts!(h::Hist1D, TA::Tuple{T}, r::AbstractRange, weights::Nothing) where T
-    A = TA[1]
+_fast_bincounts!(h::Hist1D, TA::Tuple{T}, r::AbstractRange, ::Nothing) where T = _fast_bincounts_1d!(h, TA[1], r)
+
+function _fast_bincounts_1d!(h::Hist1D, A, r::AbstractRange)
     overflow = h.overflow
     counts = bincounts(h)
-    s2 = sumw2(h)
     firstr = first(r)
     invstep = inv(step(r))
     L = nbins(h)


### PR DESCRIPTION
## The timing is distribution dependent

```julia
julia> @benchmark Hist1D(x; binedges=range(-1,1;length=11)) setup=x=rand(10^6)
BenchmarkTools.Trial: 1621 samples with 1 evaluation.
 Range (min … max):  1.418 ms …   2.619 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     1.803 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   1.814 ms ± 136.134 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

                    ▂▃▂▂▆▇▄▆▆███▆▄▇▆▆▃▆▃▃▄▂▃▁▂▁
  ▂▂▂▂▃▁▁▂▃▂▄▄▄▄▄▆▇████████████████████████████▆▇▆▆▅▅▅▅▆▅▄▄▂▂ ▆
  1.42 ms         Histogram: frequency by time        2.14 ms <

 Memory estimate: 592 bytes, allocs estimate: 8.

julia> @benchmark Hist1D(x; binedges=range(-1,1;length=11)) setup=x=randn(10^6)
BenchmarkTools.Trial: 710 samples with 1 evaluation.
 Range (min … max):  5.025 ms …  5.351 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     5.133 ms              ┊ GC (median):    0.00%
 Time  (mean ± σ):   5.136 ms ± 46.322 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

                 ▃ ▃▂▃ ▄▁▃▂█▅▃▅▆▄▂▃  ▅▁
  ▃▁▂▃▃▃▁▅▅▄▆▅▆▅▇█▇████████████████▇▇██▆▆▅▅▆▇▄▄▆▅▃▃▃▂▃▄▄▃▃▃▂ ▅
  5.03 ms        Histogram: frequency by time        5.26 ms <

 Memory estimate: 592 bytes, allocs estimate: 8.
```

```python
In [1]: import numpy as np

In [2]: x = np.random.random(10**6)

In [3]: %timeit np.histogram(x, bins=10, range=(-1, 1))
6.13 ms ± 66.7 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)

In [4]: x = np.random.normal(size=10**6)

In [5]: %timeit np.histogram(x, bins=10, range=(-1, 1))
8.09 ms ± 30.9 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```