### PR TITLE
Fix-up docs content and infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-/Manifest.toml
+Manifest.toml

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 Manifest.toml
+docs/build/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 Manifest.toml
 docs/build/
+docs/src/notebooks/makie_plotting.md
+docs/src/notebooks/plots_plotting.md

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Fast, error-aware, and thread-safe 1D/2D/3D histograms that are also compatible 
   - due to huge latency issue, UnicodePlots.jl (for text based terminal display) has been dropped.
 
 ## Quick Start
-```julia
+```julia-repl
 julia> using FHist
 
 julia> a = randn(1000);
@@ -37,7 +37,7 @@ true
 
 Additionally, one can specify `overflow=true` when creating a histogram to clamp out-of-bounds values into 
 the edge bins.
-```julia
+```julia-repl
 julia> Hist1D(rand(1000); binedges = 0:0.2:0.9, overflow=true)
 edges: 0.0:0.2:0.8
 bin counts: [218, 183, 198, 401]
@@ -47,7 +47,7 @@ total count: 1000
 ## Speed
 
 Single-threaded filling happens at ~1 GHz on modern CPU (Ryzen 7 7840HS)
-```julia
+```julia-repl
 julia> a = randn(10^6);
 
 julia> @benchmark Hist1D(a; binedges = -3:0.01:3)
@@ -59,7 +59,7 @@ BenchmarkTools.Trial: 4624 samples with 1 evaluation.
 
 ### 1D
 
-```julia
+```julia-repl
 julia> using FHist, Statistics
 
 julia> h1 = Hist1D(randn(10^4).+2; binedges = -5:0.5:5);
@@ -104,7 +104,7 @@ julia> h1 |> normalize |> integral
 
 ### 2D
 
-```julia
+```julia-repl
 julia> h2 = Hist2D((randn(10^4),randn(10^4)); binedges = (-5:5,-5:5))
 
 edges: (-5:5, -5:5)
@@ -134,7 +134,7 @@ total count: 10000
 
 ### 3D
 
-```julia
+```julia-repl
 julia> h3 = Hist3D((randn(10^4),randn(10^4),randn(10^4)); binedges = (-5:5,-5:5,-5:5))
 Hist3D{Int64}, edges=(-5:5, -5:5, -5:5), integral=10000
 

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -8,3 +8,6 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Pluto = "c3e4b0f8-55cb-11ea-2926-15256bba5781"
 PlutoStaticHTML = "359b1769-a58e-495b-9770-312e911026ad"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[sources]
+FHist = {path = ".."}

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -11,7 +11,7 @@ include("build.jl")
 
 build()
 md_files = markdown_files()
-T = [t => f for (t, f) in zip(notebooks, md_files)]
+T = notebooks .=> md_files
 
 makedocs(;
     modules=[FHist],

--- a/docs/src/notebooks/makie_plotting.jl
+++ b/docs/src/notebooks/makie_plotting.jl
@@ -17,6 +17,11 @@ end;
 # ╔═╡ 82a6fb18-e9c9-450d-9c93-e05bd6cf5859
 using FHist, CairoMakie
 
+# ╔═╡ 85400a26-57ba-4fd8-899d-654bd4ec8fd3
+md"""
+# Makie plotting
+"""
+
 # ╔═╡ 180e65b9-13db-4b0c-8b16-369b6978cec0
 md"""
 Let's generate three dummy histograms sampled from three different distributions:
@@ -207,7 +212,7 @@ end
 
 # ╔═╡ 2f97d05b-9103-451e-8fce-bb7458acf2ba
 md"""
-# Shading/Hatching errorbar band
+## Shading/Hatching errorbar band
 
 """
 
@@ -226,6 +231,7 @@ stackedhist([h1, h1]; error_color=Pattern('/'; width=0.5, tilesize=(4,4)))
 
 # ╔═╡ Cell order:
 # ╠═4cf8f502-eba2-11ec-275f-3f1858e4c2e6
+# ╠═85400a26-57ba-4fd8-899d-654bd4ec8fd3
 # ╠═82a6fb18-e9c9-450d-9c93-e05bd6cf5859
 # ╠═180e65b9-13db-4b0c-8b16-369b6978cec0
 # ╠═8491f5c3-93b6-4670-8f6e-0d08d7afbf75

--- a/docs/src/notebooks/makie_plotting.jl
+++ b/docs/src/notebooks/makie_plotting.jl
@@ -13,7 +13,7 @@ let
     using Pkg: Pkg
     Pkg.activate(docs_dir)
     Pkg.develop(; path=pkg_dir)
-    Pkg.update()
+    Pkg.instantiate()
 end;
 
 # ╔═╡ 82a6fb18-e9c9-450d-9c93-e05bd6cf5859

--- a/docs/src/notebooks/makie_plotting.jl
+++ b/docs/src/notebooks/makie_plotting.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.20.8
+# v0.20.21
 
 using Markdown
 using InteractiveUtils
@@ -8,11 +8,9 @@ using InteractiveUtils
 # hideall
 let
     docs_dir = dirname(dirname(@__DIR__))
-    pkg_dir = dirname(docs_dir)
 
     using Pkg: Pkg
     Pkg.activate(docs_dir)
-    Pkg.develop(; path=pkg_dir)
     Pkg.instantiate()
 end;
 

--- a/docs/src/notebooks/makie_plotting.jl
+++ b/docs/src/notebooks/makie_plotting.jl
@@ -215,19 +215,16 @@ md"""
 
 # ╔═╡ b114c8a7-5f01-44fe-9660-b5021d359399
 let
-    f, a, p = stackedhist([h1, h1 ]; error_color=(:black, 0.5))
+	fig, ax, plt = stackedhist([h1, h1 ]; error_color=(:black, 0.5))
 	labels = ["proc1", "blah"]
-	elements = [PolyElement(polycolor = p.attributes.color[][i]) for i in 1:length(labels)]
+	elements = [PolyElement(polycolor = plt.attributes.color[][i]) for i in 1:length(labels)]
 	title = "Legend title"
-	Legend(f[1,2], elements, labels, title)
-	f
+	Legend(fig[1,2], elements, labels, title)
+	fig
 end
 
 # ╔═╡ fae56f0f-bac4-4dea-b33c-d45e6f3b51fc
-let
-    f, a, p = stackedhist([h1, h1]; error_color=Pattern('/'; width=0.5, tilesize=(4,4)))
-	f
-end
+stackedhist([h1, h1]; error_color=Pattern('/'; width=0.5, tilesize=(4,4)))
 
 # ╔═╡ Cell order:
 # ╠═4cf8f502-eba2-11ec-275f-3f1858e4c2e6

--- a/docs/src/notebooks/plots_plotting.jl
+++ b/docs/src/notebooks/plots_plotting.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.19.32
+# v0.20.21
 
 using Markdown
 using InteractiveUtils
@@ -8,11 +8,9 @@ using InteractiveUtils
 # hideall
 let
     docs_dir = dirname(dirname(@__DIR__))
-    pkg_dir = dirname(docs_dir)
 
     using Pkg: Pkg
     Pkg.activate(docs_dir)
-    Pkg.develop(; path=pkg_dir)
     Pkg.instantiate()
 end;
 

--- a/docs/src/notebooks/plots_plotting.jl
+++ b/docs/src/notebooks/plots_plotting.jl
@@ -17,6 +17,11 @@ end;
 # ╔═╡ 5a884f80-7c0a-4345-b2d3-1785b1b5a46a
 using FHist, Statistics, Plots
 
+# ╔═╡ 92a9373e-7b27-4a8a-ac03-8f6be86063c9
+md"""
+# Plots plotting
+"""
+
 # ╔═╡ d604a07e-2179-4570-b6bb-df3b8f6cfc7e
 md"## Hist1D"
 
@@ -52,6 +57,7 @@ end
 
 # ╔═╡ Cell order:
 # ╠═be0b45f2-86dc-11ee-2dce-2994fb540eec
+# ╟─92a9373e-7b27-4a8a-ac03-8f6be86063c9
 # ╠═5a884f80-7c0a-4345-b2d3-1785b1b5a46a
 # ╟─d604a07e-2179-4570-b6bb-df3b8f6cfc7e
 # ╟─6ebafb79-448b-425a-890a-39ae454816be

--- a/docs/src/notebooks/plots_plotting.jl
+++ b/docs/src/notebooks/plots_plotting.jl
@@ -50,10 +50,10 @@ end
 md"## Hist2D"
 
 # ╔═╡ 53eacafc-71ac-4e70-a238-581335ac4729
-begin
-		h2d = Hist2D((randn(10000), randn(10000)))
-		p2d = plot(h2d)
-end
+h2d = Hist2D((randn(10000), randn(10000)));
+
+# ╔═╡ 8ebab27d-f213-487f-9467-beadcf5dc792
+p2d = plot(h2d)
 
 # ╔═╡ Cell order:
 # ╠═be0b45f2-86dc-11ee-2dce-2994fb540eec
@@ -65,3 +65,4 @@ end
 # ╠═2d857d08-f9c2-4a60-86dd-2afbd3b599f6
 # ╟─68d705dd-d0d9-4394-8d3c-f8b2113e6cef
 # ╠═53eacafc-71ac-4e70-a238-581335ac4729
+# ╠═8ebab27d-f213-487f-9467-beadcf5dc792

--- a/docs/src/writingtohdf5.md
+++ b/docs/src/writingtohdf5.md
@@ -30,8 +30,8 @@ including all the meta information needed to be able to recreate it. This is how
 it looks like when opening it with `HDF5.jl` (any other HDF5 library will look
 similarly):
 
-```
-f = HDF5.File: (read-only) foo.h5
+```julia-repl
+julia> f = HDF5.File: (read-only) foo.h5
 🗂️ HDF5.File: (read-only) foo.h5
 └─ 📂 some
    └─ 📂 path

--- a/docs/src/writingtoroot.md
+++ b/docs/src/writingtoroot.md
@@ -7,7 +7,7 @@ ENV["JULIA_PYTHONCALL_EXE"] = readchomp(`which python`)
 ```
 before the `using PythonCall` line. Especially if you're using LCG or Athena or CMSSW environment.
 
-```julia
+```julia-repl
 julia> using PythonCall, FHist
 
 julia> np = pyimport("numpy")
@@ -35,18 +35,18 @@ julia> pywith(up.recreate("./example.root")) do file
 ### Writing out a histogram with errors (sumW2)
 We need https://github.com/scikit-hep/hist for this:
 
-```julia
+```julia-repl
 julia> using PythonCall, FHist
 
 julia> function to_pyhist(h::Hist1D)
-    pyhist = pyimport("hist")
-    bes, bcs, sumw2s = binedges(h), bincounts(h), sumw2(h)
-    h1 = pyhist.Hist.new.Variable(collect(bes)).Weight()
-    for idx in eachindex(bcs, sumw2s)
-        h1.view()[idx-1] = (bcs[idx], sumw2s[idx])
-    end
-    h1
-end
+           pyhist = pyimport("hist")
+           bes, bcs, sumw2s = binedges(h), bincounts(h), sumw2(h)
+           h1 = pyhist.Hist.new.Variable(collect(bes)).Weight()
+           for idx in eachindex(bcs, sumw2s)
+               h1.view()[idx-1] = (bcs[idx], sumw2s[idx])
+           end
+           h1
+       end
 
 julia> pywith(up.recreate("./example.root")) do file
            file["myhist"] = to_pyhist(h)
@@ -54,7 +54,7 @@ julia> pywith(up.recreate("./example.root")) do file
 ```
 
 we can veryfy the round trip gives us back the original number:
-```julia
+```julia-repl
 julia> binerrors(h)
 100-element Vector{Float64}:
  0.0

--- a/docs/src/writingtoroot.md
+++ b/docs/src/writingtoroot.md
@@ -1,5 +1,5 @@
 ### Write out a histogram
-Checkout configuration for PythonCall.jl: https://cjdoris.github.io/PythonCall.jl/stable/pythoncall/#pythoncall-config
+Checkout configuration for PythonCall.jl: <https://cjdoris.github.io/PythonCall.jl/stable/pythoncall/#pythoncall-config>
 
 Most importantly, you probably want to set:
 ```julia
@@ -33,7 +33,7 @@ julia> pywith(up.recreate("./example.root")) do file
 ```
 
 ### Writing out a histogram with errors (sumW2)
-We need https://github.com/scikit-hep/hist for this:
+We need <https://github.com/scikit-hep/hist> for this:
 
 ```julia-repl
 julia> using PythonCall, FHist

--- a/src/FHist.jl
+++ b/src/FHist.jl
@@ -160,7 +160,7 @@ for (H, N) in ((:Hist1D, 1), (:Hist2D, 2), (:Hist3D, 3))
         Get the number of effective entries for the entire histogram:
 
         ```math
-        n_{eff} = \frac{(\sum Weights )^2}{(\sum Weight^2 )}
+        n_\text{eff} = \frac{(\sum \text{Weights} )^2}{(\sum \text{Weight}^2 )}
         ```
 
         This is also equivalent to `integral(hist)^2 / sum(sumw2(hist))`, this is the same as `TH1::GetEffectiveEntries()`

--- a/src/FHist.jl
+++ b/src/FHist.jl
@@ -113,8 +113,9 @@ for (H, N) in ((:Hist1D, 1), (:Hist2D, 2), (:Hist3D, 3))
         Base.lock(h::$H) = lock(h.hlock)
         Base.unlock(h::$H) = unlock(h.hlock)
         @doc """
-                bincounts(h::$($H))
-            Get the bin counts (weights) of the histogram.
+            bincounts(h::$($H))
+
+        Get the bin counts (weights) of the histogram.
         """
         bincounts(h::$H) = h.bincounts
         @doc """

--- a/src/MakieThemes.jl
+++ b/src/MakieThemes.jl
@@ -1,4 +1,5 @@
 """
+    ATLASTHEME
 
 ## Example
 ```

--- a/src/arithmatics.jl
+++ b/src/arithmatics.jl
@@ -68,9 +68,10 @@ accurate algorithm than the naive `S / sqrt(B)`
 Ref: <https://cds.cern.ch/record/2736148/files/ATL-PHYS-PUB-2020-025.pdf>
 
 ## Example:
-```julia
-h1 = Hist1D(rand(1000);  binedges = [0, 0.5])
-h2 = Hist1D(rand(10000); binedges = [0, 0.5]);
+```julia-repl
+julia> h1 = Hist1D(rand(1000);  binedges = [0, 0.5]);
+
+julia> h2 = Hist1D(rand(10000); binedges = [0, 0.5]);
 
 julia> s1 = significance(h1,h2)
 (6.738690967342175, 0.3042424717261312)

--- a/src/arithmatics.jl
+++ b/src/arithmatics.jl
@@ -65,7 +65,7 @@ end
 Calculate the significance of signal vs. bkg histograms, this function uses a more
 accurate algorithm than the naive `S / sqrt(B)`
 
-Ref: https://cds.cern.ch/record/2736148/files/ATL-PHYS-PUB-2020-025.pdf
+Ref: <https://cds.cern.ch/record/2736148/files/ATL-PHYS-PUB-2020-025.pdf>
 
 ## Example:
 ```julia

--- a/src/hist3d.jl
+++ b/src/hist3d.jl
@@ -65,7 +65,7 @@ end
 Base.broadcastable(h::Hist3D) = Ref(h)
 
 """
-    function lookup(h::Hist3D, x, y, z)
+    lookup(h::Hist3D, x, y, z)
 
 For given x/y/z-axis value `x`, `y`, `z`, find the corresponding bin and return the bin content.
 If a value is out of the histogram range, return `missing`.

--- a/src/polybinedges.jl
+++ b/src/polybinedges.jl
@@ -1,7 +1,7 @@
 """
     BinEdges <: AbstractVector{Float64}
 
-    This type implements a vector-like data structure to be used for histogram bin edges, it can handle both uniform and non-uniform binnings in a single type to reduce the amount of parametric types. It would switch to O(1) `searchsortedlast` if the binning is uniform.
+This type implements a vector-like data structure to be used for histogram bin edges, it can handle both uniform and non-uniform binnings in a single type to reduce the amount of parametric types. It would switch to O(1) `searchsortedlast` if the binning is uniform.
 
 !!! note
     Due to the usage of Float64, bin edges shouldn't contain element with absolute value larger than 9007199254740992, which is the `maxintfloat(Float64)`.

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -50,7 +50,7 @@ valid_rebin_values(h::Hist1D) = _factor(nbins(h))
 valid_rebin_values(h::Union{Hist2D, Hist3D}) = [_factor(x) for x in nbins(h)]
 
 """
-    function _factor(n::Integer)
+    _factor(n::Integer)
 
 Helper function to calculate the prime factors of a given integer.
 """


### PR DESCRIPTION
- Update gitignore to ignore artifacts created during docs building
- Use `[sources]` attribute in docs/Project.toml, as supported by Pkg.toml v1.11+ for docs to maintain its dependency on FHist itself.
  This does imply we should run docs on Julia v1.11+, but given that it's essentially a separate environment, and also not what we're promising the registry, it should be fine since CI automatically picks the newest version anyway.
  It also lets us do away with the `Pkg.develop()` call in the notebooks.
- Add headings to docs notebooks
- Update example blocks
- Fix-up various docstrings

Each commit and its associated message contains a more atomic change and its description.