### PR TITLE
Load Measurements only in the Makie extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -46,5 +46,5 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 
 [targets]
-test = ["Test", "HDF5", "Aqua"]
+test = ["Test", "HDF5", "Aqua", "CairoMakie"]
 docs = ["Test", "HDF5", "CairoMakie", "Plots"]

--- a/ext/FHistMakieExt.jl
+++ b/ext/FHistMakieExt.jl
@@ -1,5 +1,5 @@
 module FHistMakieExt
-using FHist, FHist.Measurements
+using FHist, Measurements
 using Statistics
 isdefined(Base, :get_extension) ? (using Makie) : (using ..Makie)
 

--- a/src/FHist.jl
+++ b/src/FHist.jl
@@ -8,7 +8,7 @@ export Hist2D, project, profile, transpose
 
 export Hist3D, collabtext!, statbox!
 
-using StatsBase, Statistics, Measurements
+using StatsBase, Statistics
 export Weights
 import LinearAlgebra: normalize, normalize!
 using Base.Threads: SpinLock

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,9 @@
-using FHist, StatsBase, Statistics, HDF5
+using FHist, StatsBase, Statistics, HDF5, CairoMakie
 using Test
 using Aqua
 
 @testset "Aqua" begin
-    Aqua.test_all(FHist)
+    Aqua.test_all(FHist; stale_deps=(; ignore=[:Measurements]))
 end
 
 @testset "Fast route" begin
@@ -667,3 +667,16 @@ end
 include("test-algebraic-content.jl")
 
 include("hdf5.jl")
+
+@testset "Makie extension" begin
+    h1 = Hist1D(randn(1000); binedges = -3:0.5:3)
+    h2 = Hist2D((randn(1000), randn(1000)); binedges = (-3:0.5:3, -3:0.5:3))
+    h3 = Hist3D((randn(1000), randn(1000), randn(1000)); binedges = (-3:3, -3:3, -3:3))
+
+    @test plot(h1) isa Makie.FigureAxisPlot
+    @test plot(h2) isa Makie.FigureAxisPlot
+    @test plot(h3) isa Makie.FigureAxisPlot
+    @test stairs(h1) isa Makie.FigureAxisPlot
+    @test stackedhist([h1, h1]) isa Makie.FigureAxisPlot
+    @test ratiohist(h1) isa Makie.FigureAxisPlot
+end


### PR DESCRIPTION
This saves on load time and invalidations when not used with Makie.

In particular, removes these invalidations when loaded without Makie:
```julia
 inserting convert(::Type{Measurements.Measurement}, a::Real) @ Measurements ~/.julia/packages/Measurements/FIcLC/src/conversions.jl:50 invalidated:                                                                                           
   backedges: 1: superseding convert(::Type{T}, x::T) where T<:Number @ Base number.jl:6 with MethodInstance for convert(::Type{T}, ::Real) where T<:Real (2 children)                                                                         
              2: superseding convert(::Type{T}, x::Number) where T<:Number @ Base number.jl:7 with MethodInstance for convert(::Type{T} where T<:Real, ::Int64) (3 children)                                                                   
 
inserting one(::Type{Measurements.Measurement{T}}) where T @ Measurements ~/.julia/packages/Measurements/FIcLC/src/math.jl:792 invalidated:                                                                                                   
   backedges: 1: superseding one(::Type{T}) where T<:Number @ Base number.jl:355 with MethodInstance for one(::Type{T} where T<:Real) (11 children)                                                                                            
 
 inserting floor(::Type{T}, a::Measurements.Measurement) where T<:Integer @ Measurements ~/.julia/packages/Measurements/FIcLC/src/math.jl:752 invalidated:
   backedges: 1: superseding floor(::Type{T}, x) where T @ Base rounding.jl:475 with MethodInstance for floor(::Type{Int64}, ::Any) (18 children)

 inserting ceil(::Type{T}, a::Measurements.Measurement) where T<:Integer @ Measurements ~/.julia/packages/Measurements/FIcLC/src/math.jl:755 invalidated:
   backedges: 1: superseding ceil(::Type{T}, x) where T @ Base rounding.jl:476 with MethodInstance for ceil(::Type{Int64}, ::Any) (30 children)
              2: superseding ceil(::Type{T}, x) where T @ Base rounding.jl:476 with MethodInstance for ceil(::Type{Integer}, ::Any) (68 children)

 inserting convert(::Type{Int64}, a::Measurements.Measurement) @ Measurements ~/.julia/packages/Measurements/FIcLC/src/conversions.jl:53 invalidated:
   backedges: 1: superseding convert(::Type{T}, x::Number) where T<:Number @ Base number.jl:7 with MethodInstance for convert(::Type{Int64}, ::Number) (2 children)
              2: superseding convert(::Type{T}, x::Number) where T<:Number @ Base number.jl:7 with MethodInstance for convert(::Type{T} where T<:Real, ::Real) (14 children)
              3: superseding convert(::Type{T}, x::Number) where T<:Number @ Base number.jl:7 with MethodInstance for convert(::Type{Int64}, ::Real) (417 children)
```

I also added some smoke tests for the Makie plots. Would it be possible to make a new release with this?