### PR TITLE
fix Makie stackedhist with non-uniform binning

### DIFF
--- a/ext/FHistMakieExt.jl
+++ b/ext/FHistMakieExt.jl
@@ -106,6 +106,7 @@ function Makie.plot!(input::StackedHist{<:Tuple{AbstractVector{<:Hist1D}}})
         stack=grp,
         color=c[grp],
         gap=input[:gap],
+        width=mapreduce(diff ∘ binedges, vcat, hs),
     )
 
     error_color = input[:error_color]


### PR DESCRIPTION
Fixed barplot with non-uniformly binned histogram

Before
<img width="610" height="484" alt="image" src="https://github.com/user-attachments/assets/8cf4b187-89a2-475c-954a-7c6e3f29e91a" />

After
<img width="610" height="484" alt="image" src="https://github.com/user-attachments/assets/4dd10d1f-e462-41f9-bc18-2b478fb0a49d" />

```julia
julia> be = [0, 0.3, 1];

julia> stackedhist([Hist1D(rand(100); binedges=be), Hist1D(rand(200); binedges=be), Hist1D(rand(100); binedges=be)])
```